### PR TITLE
26 fr add option for maximum trip length in resrobot travel search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ There's also a couple of Lovelace dashboard cards to use as companions to this i
 - **Line filtering**: Monitor specific lines by filtering with comma-separated line numbers, per sensor
 - **Destination filtering**: Filter by (substring) text match of destination(s) at a stop (useful for busy stops), per sensor
 - **Configurable time window**: Set how many minutes ahead to search (1-1440 minutes), per sensor
+- **Maximum trip duration filter (new in v0.7.0)**: For Travel Search sensors, exclude trips whose total duration exceeds a configurable limit (1-1440 minutes). Leave empty for no limit. Backward compatible — existing config entries without this setting are unaffected.
 - **Multiple transport modes**: Support for buses, trains, metro, trams, and ships
 - **Flexible sensor configuration**: Create separate sensors for departures and arrivals
 - **Stop lookup service**: Search for the stop ID by it's name using Home Assistant service
@@ -75,6 +76,7 @@ Note about Resrobot: Trip planning uses Resrobot Travel Search which requires it
      - Origin and Destination: each can be a Stop ID or coordinates "lat,lon" (select type for each)
      - Optional via/avoid Stop IDs and maximum walking distance
      - Time window and refresh interval
+     - Optional maximum trip duration (in minutes) — trips longer than this are excluded from results
 5. Finish to create the sensor.
 
 **Note**: The integration now uses **area IDs** from the Trafiklab Realtime API, which correspond to "rikshållplatser" (national stops) or meta-stops. Use the stop lookup service to find the correct area ID for your stop.
@@ -113,6 +115,20 @@ The integration creates sensors based on your configuration:
 - **Device Class**: Duration
 - **Attributes**: Normalized list of trips and legs (origin/destination times, product, category, duration, etc.)
 
+#### Maximum Trip Duration Filter (new in v0.7.0)
+
+Travel Search sensors support an optional **Maximum Trip Duration** setting (1–1440 minutes). When set, any trip whose total travel time (first leg departure → last leg arrival) exceeds the limit is excluded from the `trips` attribute and cannot become the sensor state.
+
+Leave the field empty (or set to `None`) for no limit. This is the default, so existing sensors without this option are fully backward compatible.
+
+Each trip in the `trips` attribute now always includes a `duration_total` key (integer minutes, or `null` if times could not be parsed).
+
+```yaml
+# Example: only show trips shorter than 1 hour
+options:
+  max_trip_duration: 60
+```
+
 
 ### Sensor Attributes
 
@@ -130,6 +146,32 @@ All sensors include comprehensive attributes for automation use:
 - `canceled`: Boolean indicating if canceled
 - `platform`: Platform or stop position
 - `upcoming`: Array of upcoming departures/arrivals (see structure below)
+- `trips`: (Travel Search only) Array of upcoming trips — see structure below
+
+#### Travel Search Trips Array Structure
+
+The `trips` attribute on Travel Search sensors contains a sorted array of trips, each with:
+
+```json
+{
+  "index": 0,                           // Position in sorted list (0-based)
+  "duration_total": 45,                 // Total trip duration in minutes (null if unparseable)
+  "legs": [
+    {
+      "origin_name": "Stockholm C",     // Departure stop name
+      "origin_time": "2025-08-08 14:30:00", // Departure date+time
+      "dest_name": "Uppsala C",         // Arrival stop name
+      "dest_time": "2025-08-08 15:15:00",   // Arrival date+time
+      "type": "Public Transport",        // Leg type (Public Transport / Transfer / Walk to/from)
+      "product": "SJ Regional",          // Product/service name
+      "direction": "Uppsala",            // Headsign/direction
+      "line_number": "42",               // Line number
+      "category": "Train",               // Translated transport category
+      "duration": 45                     // Leg duration in minutes
+    }
+  ]
+}
+```
 
 #### Upcoming Departures/Arrivals Array Structure
 

--- a/custom_components/trafiklab/config_flow.py
+++ b/custom_components/trafiklab/config_flow.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_VIA,
     CONF_AVOID,
     CONF_MAX_WALKING_DISTANCE,
+    CONF_MAX_TRIP_DURATION,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -238,6 +239,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_VIA, default=""): str,
             vol.Optional(CONF_AVOID, default=""): str,
             vol.Optional(CONF_MAX_WALKING_DISTANCE, default=1000): vol.All(vol.Coerce(int), vol.Range(min=0, max=10000)),
+            vol.Optional(CONF_MAX_TRIP_DURATION, default=None): vol.Any(None, vol.All(vol.Coerce(int), vol.Range(min=1, max=1440))),
             vol.Optional(CONF_REFRESH_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=MINIMUM_SCAN_INTERVAL, max=3600)),
             vol.Optional(CONF_TIME_WINDOW, default=DEFAULT_TIME_WINDOW): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
         })
@@ -251,6 +253,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             via = user_input.get("via", "")
             avoid = user_input.get("avoid", "")
             max_walking_distance = user_input.get("max_walking_distance", 1000)
+            max_trip_duration = user_input.get(CONF_MAX_TRIP_DURATION)
             refresh_interval = user_input.get("refresh_interval", DEFAULT_SCAN_INTERVAL)
             time_window = user_input.get("time_window", DEFAULT_TIME_WINDOW)
 
@@ -284,6 +287,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "via": via,
                     "avoid": avoid,
                     "max_walking_distance": max_walking_distance,
+                    CONF_MAX_TRIP_DURATION: user_input.get(CONF_MAX_TRIP_DURATION),
                     "refresh_interval": refresh_interval,
                     "time_window": time_window,
                 }
@@ -379,6 +383,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_AVOID, default=""): str,
                 vol.Optional(CONF_MAX_WALKING_DISTANCE, default=1000): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=10000)
+                ),
+                vol.Optional(CONF_MAX_TRIP_DURATION, default=None): vol.Any(
+                    None, vol.All(vol.Coerce(int), vol.Range(min=1, max=1440))
                 ),
                 vol.Optional(CONF_REFRESH_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
                     vol.Coerce(int), vol.Range(min=MINIMUM_SCAN_INTERVAL, max=3600)

--- a/custom_components/trafiklab/const.py
+++ b/custom_components/trafiklab/const.py
@@ -24,6 +24,7 @@ CONF_DESTINATION: Final = "destination"
 CONF_VIA: Final = "via"
 CONF_AVOID: Final = "avoid"
 CONF_MAX_WALKING_DISTANCE: Final = "max_walking_distance"
+CONF_MAX_TRIP_DURATION: Final = "max_trip_duration"
 
 
 # Sensor types

--- a/custom_components/trafiklab/sensor.py
+++ b/custom_components/trafiklab/sensor.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_SENSOR_TYPE,
     CONF_DIRECTION,
     CONF_LINE_FILTER,
+    CONF_MAX_TRIP_DURATION,
     SENSOR_TYPE_ARRIVAL,
     SENSOR_TYPE_RESROBOT,
 )
@@ -125,8 +126,9 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             if not trips_raw:
                 return None
             # Normalize + sort trips/legs locally as well (in case coordinator didn't)
-            trips_sorted = self._normalize_resrobot_trips(trips_raw)
             options = {**self._entry.options, **self._entry.data}
+            max_trip_duration: int | None = options.get(CONF_MAX_TRIP_DURATION)
+            trips_sorted = self._normalize_resrobot_trips(trips_raw, max_trip_duration)
             time_window = int(options.get("time_window", 60))
             from datetime import datetime
             now = datetime.now()
@@ -184,7 +186,9 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             trips_raw = self.coordinator.data.get("Trip", [])
             if not trips_raw:
                 return {}
-            trips_sorted = self._normalize_resrobot_trips(trips_raw)
+            options_merged = {**self._entry.options, **self._entry.data}
+            max_trip_duration: int | None = options_merged.get(CONF_MAX_TRIP_DURATION)
+            trips_sorted = self._normalize_resrobot_trips(trips_raw, max_trip_duration)
             return {
                 "num_trips": len(trips_sorted),
                 "trips": trips_sorted,
@@ -269,7 +273,7 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             )
         return upcoming
 
-    def _normalize_resrobot_trips(self, trips_raw: Any) -> list[dict[str, Any]]:
+    def _normalize_resrobot_trips(self, trips_raw: Any, max_trip_duration: int | None = None) -> list[dict[str, Any]]:
         """Normalize and sort ResRobot trips and their legs for attribute exposure.
 
         Returns a list of trips where each has a key "legs" which is a list of
@@ -435,16 +439,46 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
                 torg = (trip or {}).get("Origin", {}) or {}
                 first_leg_dt = parse_dt(torg.get("date", ""), torg.get("time", "")) or datetime.max
 
+            # Compute total trip duration: first leg origin_time → last leg dest_time
+            duration_total: int | None = None
+            if simplified_legs:
+                first_leg = simplified_legs[0]
+                last_leg = simplified_legs[-1]
+                origin_dt = parse_dt(
+                    *first_leg.get("origin_time", " ").split(" ", 1)
+                ) if " " in first_leg.get("origin_time", "") else None
+                dest_str = last_leg.get("dest_time", "")
+                dest_dt: datetime | None = None
+                if dest_str:
+                    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+                        try:
+                            dest_dt = datetime.strptime(dest_str, fmt)
+                            break
+                        except ValueError:
+                            continue
+                if origin_dt is not None and dest_dt is not None:
+                    duration_total = max(0, int((dest_dt - origin_dt).total_seconds() / 60))
+
+            # Filter by max_trip_duration when set (None = no limit, backward compatible)
+            if (
+                max_trip_duration is not None
+                and duration_total is not None
+                and duration_total > max_trip_duration
+            ):
+                continue
+
             trips_out.append({
                 "index": idx,
                 "legs": simplified_legs,
+                "duration_total": duration_total,
                 "_dt": first_leg_dt,
             })
 
         # Sort trips by first leg datetime
         trips_out.sort(key=lambda t: t.get("_dt") or datetime.max)
-        for tp in trips_out:
+        for out_idx, tp in enumerate(trips_out):
             tp.pop("_dt", None)
+            tp["index"] = out_idx
         return trips_out
 
     def _get_data_items(self) -> list[dict]:

--- a/custom_components/trafiklab/translations/en.json
+++ b/custom_components/trafiklab/translations/en.json
@@ -43,6 +43,7 @@
           "via": "Via",
           "avoid": "Avoid",
           "max_walking_distance": "Maximum Walking Distance (meters)",
+          "max_trip_duration": "Maximum Trip Duration (minutes, leave empty for no limit)",
           "time_window": "Time Window (minutes ahead to search)",
           "refresh_interval": "Data Refresh Interval (seconds)"
         },
@@ -118,6 +119,7 @@
         "data": {
           "line_filter": "Line Filter (comma-separated, leave empty for all lines)",
           "direction": "Destination Filter (substring; leave empty for all destinations)",
+          "max_trip_duration": "Maximum Trip Duration (minutes, leave empty for no limit)",
           "time_window": "Time Window (minutes ahead to search)",
           "refresh_interval": "Data Refresh Interval (seconds)",
           "update_condition": "Update Condition (template; render to 'true' to fetch)"

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -43,6 +43,7 @@
           "via": "Via",
           "avoid": "Undvik",
           "max_walking_distance": "Maximalt gångavstånd (meter)",
+          "max_trip_duration": "Maximal resetid (minuter, lämna tomt för ingen gräns)",
           "time_window": "Tidsfönster (minuter framåt att söka)",
           "refresh_interval": "Datauppdateringsintervall (sekunder)"
         },
@@ -118,6 +119,7 @@
         "data": {
           "line_filter": "Linjefilter (kommaseparerade, lämna tomt för alla linjer)",
           "direction": "Destinationsfilter (textdel; lämna tomt för alla destinationer)",
+          "max_trip_duration": "Maximal resetid (minuter, lämna tomt för ingen gräns)",
           "time_window": "Tidsfönster (minuter framåt att söka)",
           "refresh_interval": "Datauppdateringsintervall (sekunder)",
           "update_condition": "Uppdateringsvillkor (mall; rendera till 'true' för att hämta)"

--- a/tests/components/trafiklab/test_sensor.py
+++ b/tests/components/trafiklab/test_sensor.py
@@ -80,3 +80,224 @@ async def test_sensor_resrobot_shows_minutes_until_and_trips(hass: HomeAssistant
     attrs = entity_state.attributes
     assert "trips" in attrs
     assert attrs.get("integration") == DOMAIN
+
+
+# ---------------------------------------------------------------------------
+# Tests for max_trip_duration and duration_total
+# ---------------------------------------------------------------------------
+
+def _make_resrobot_response_with_duration(dep_time: str, arr_time: str, date: str = "2099-12-31") -> dict:
+    """Build a minimal single-trip ResRobot response with configurable dep/arr times."""
+    return {
+        "Trip": [
+            {
+                "LegList": {
+                    "Leg": [
+                        {
+                            "Origin": {"name": "Stop A", "date": date, "time": dep_time},
+                            "Destination": {"name": "Stop B", "date": date, "time": arr_time},
+                            "Product": {"name": "Bus 52", "num": "52"},
+                            "category": "BUS",
+                            "duration": "PT20M",
+                            "direction": "Central Station",
+                            "idx": 1,
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_resrobot_duration_total_in_attributes(hass: HomeAssistant) -> None:
+    """duration_total must be present in every trip entry in sensor attributes."""
+    # Trip runs 12:00 → 12:45 = 45 minutes
+    mock_resp = _make_resrobot_response_with_duration("12:00:00", "12:45:00")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "key",
+            "name": "DurTest",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000001",
+            "destination_type": "stop_id",
+            "destination": "740000002",
+        },
+        options={"time_window": 9999, "refresh_interval": 300},
+        unique_id="dur_total_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search", return_value=mock_resp):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_resrobot_travel")
+    assert entity_id is not None
+    attrs = hass.states.get(entity_id).attributes
+    assert "trips" in attrs
+    trips = attrs["trips"]
+    assert len(trips) == 1
+    assert "duration_total" in trips[0]
+    assert trips[0]["duration_total"] == 45
+
+
+@pytest.mark.asyncio
+async def test_resrobot_max_trip_duration_filters_long_trips(hass: HomeAssistant) -> None:
+    """Trips exceeding max_trip_duration must not appear in sensor attributes."""
+    # Two trips: 20 min and 90 min. With max_trip_duration=30 only the 20-min trip survives.
+    mock_resp = {
+        "Trip": [
+            {
+                "LegList": {
+                    "Leg": [
+                        {
+                            "Origin": {"name": "Stop A", "date": "2099-12-31", "time": "12:00:00"},
+                            "Destination": {"name": "Stop B", "date": "2099-12-31", "time": "12:20:00"},
+                            "Product": {"name": "Bus 1", "num": "1"},
+                            "category": "BUS",
+                            "duration": "PT20M",
+                            "direction": "North",
+                            "idx": 1,
+                        }
+                    ]
+                }
+            },
+            {
+                "LegList": {
+                    "Leg": [
+                        {
+                            "Origin": {"name": "Stop A", "date": "2099-12-31", "time": "13:00:00"},
+                            "Destination": {"name": "Stop C", "date": "2099-12-31", "time": "14:30:00"},
+                            "Product": {"name": "Train 2", "num": "2"},
+                            "category": "TRN",
+                            "duration": "PT1H30M",
+                            "direction": "South",
+                            "idx": 1,
+                        }
+                    ]
+                }
+            },
+        ]
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "key",
+            "name": "FilterTest",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000010",
+            "destination_type": "stop_id",
+            "destination": "740000020",
+        },
+        options={"time_window": 9999, "refresh_interval": 300, "max_trip_duration": 30},
+        unique_id="max_dur_filter_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search", return_value=mock_resp):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_resrobot_travel")
+    assert entity_id is not None
+    attrs = hass.states.get(entity_id).attributes
+    trips = attrs.get("trips", [])
+    # Only the 20-minute trip should remain
+    assert len(trips) == 1
+    assert trips[0]["duration_total"] == 20
+
+
+@pytest.mark.asyncio
+async def test_resrobot_no_max_trip_duration_key_returns_all_trips(hass: HomeAssistant) -> None:
+    """When max_trip_duration key is absent (old config entry), all trips are returned."""
+    mock_resp = {
+        "Trip": [
+            {
+                "LegList": {
+                    "Leg": [
+                        {
+                            "Origin": {"name": "Stop A", "date": "2099-12-31", "time": "12:00:00"},
+                            "Destination": {"name": "Stop B", "date": "2099-12-31", "time": "14:00:00"},
+                            "Product": {"name": "Train 1", "num": "1"},
+                            "category": "TRN",
+                            "duration": "PT2H",
+                            "direction": "East",
+                            "idx": 1,
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    # Simulate a legacy entry: options dict has NO max_trip_duration key at all
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "key",
+            "name": "LegacyTest",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000030",
+            "destination_type": "stop_id",
+            "destination": "740000040",
+        },
+        options={"time_window": 9999, "refresh_interval": 300},  # no max_trip_duration key
+        unique_id="legacy_no_max_dur",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search", return_value=mock_resp):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_resrobot_travel")
+    assert entity_id is not None
+    attrs = hass.states.get(entity_id).attributes
+    trips = attrs.get("trips", [])
+    # All trips must be present — 120-minute trip not filtered
+    assert len(trips) == 1
+    assert trips[0]["duration_total"] == 120
+
+
+@pytest.mark.asyncio
+async def test_resrobot_max_trip_duration_none_returns_all_trips(hass: HomeAssistant) -> None:
+    """When max_trip_duration is explicitly None, all trips are returned (no limit)."""
+    mock_resp = _make_resrobot_response_with_duration("12:00:00", "15:00:00")  # 180 min
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "key",
+            "name": "NullTest",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000050",
+            "destination_type": "stop_id",
+            "destination": "740000060",
+        },
+        options={"time_window": 9999, "refresh_interval": 300, "max_trip_duration": None},
+        unique_id="null_max_dur",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search", return_value=mock_resp):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_resrobot_travel")
+    assert entity_id is not None
+    attrs = hass.states.get(entity_id).attributes
+    trips = attrs.get("trips", [])
+    assert len(trips) == 1
+    assert trips[0]["duration_total"] == 180


### PR DESCRIPTION
- Added config flow option `CONF_MAX_TRIP_DURATION` - this one filters out travels that takes longer than configured value (calculated from API returned values `depDate`, `depTime`, `arrDate` and `arrTime`). 
- Added sensor attribute `duration_total` to each trip index in array.