### PR TITLE
Dynamic route planning service with service responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ This integration is entirely community-developed and is not developed by, or in 
 
 ## Finding Your Stop ID
 
-Before you can configure any sensor, you need the **stop ID** for your location. Use the built-in `trafiklab.stop_lookup` service to find it — see [Stop ID Lookup Service](#stop-id-lookup-service) for full details.
+A **Stop ID** is required for **Realtime departure and arrival sensors**, and it is also one supported way to configure **Travel Search** sensors. Travel Search sensors and the `trafiklab.travel_search` service can also use coordinates, stop names, HA zones, or person/device_tracker entities. If you want to use a Stop ID, use the built-in `trafiklab.stop_lookup` service — see [Stop ID Lookup Service](#stop-id-lookup-service) for full details.
 
-**Quick steps:**
+**Quick steps to look up a Stop ID:**
 1. If you have no Trafiklab config entries yet, add this one-line stub to `configuration.yaml` and restart:
    ```yaml
    trafiklab:

--- a/README.md
+++ b/README.md
@@ -7,36 +7,44 @@
 [![Maintainer](https://img.shields.io/badge/maintainer-MrSjodin-blue.svg)](https://github.com/MrSjodin)
 [![License](https://img.shields.io/badge/license-CC%20BY--NC%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc/4.0/)
 
-So, here's a hopefully useful Home Assistant custom integration for Swedish public transport information by using the newer **Trafiklab Realtime API**.
+**Trafiklab** Home Assistant custom integration for Swedish public transport, using the **Trafiklab Realtime API** and **Trafiklab Resrobot API**, presents you the timetables for a stop as well as the full route plan for your travel. The integration covers all major public transport operators in Sweden — not just SL. See [Operators](#operators) for the full list.
 
-The story behind is that I'd like to be able to show the upcoming departures from our nearest stops in the Home Assistant ecosystem, a bit outside of the city (and not in the SL area). Although HASL is a great integration, the newer versions only supports SL - therefore I saw a need to have a native integration towards the **Trafiklab Realtime API** for use in more or less the whole country.
+This integration is entirely community-developed and is not developed by, or in collaboration with, Trafiklab/Samtrafiken. Trafiklab/Samtrafiken has given the project a thumbs-up though — see [Trafiklab Praise page](https://support.trafiklab.se/org/trafiklabse/d/realtime-api-integrerat-i-home-assistant/).
 
-For a complete list of traffic operators covered by the API and this integration, see [Operators](#operators) section below. 
+## Contents
 
-This integration has not been developed by, or in collaboration with, Trafiklab/Samtrafiken but is entirely community-developed. Trafiklab/Samtrafiken has been informed about the integration and has given the project a thumbs-up regarding the use of their API, etc. See [Trafiklab Praise page](https://support.trafiklab.se/org/trafiklabse/d/realtime-api-integrerat-i-home-assistant/) as reference.
+- [Features](#features)
+- [Installation](#installation)
+- [Finding Your Stop ID](#finding-your-stop-id)
+- [Configuration](#configuration)
+- [Sensors](#sensors)
+- [Services](#services)
+  - [Stop ID Lookup](#stop-id-lookup-service)
+  - [Update Now](#update-now-service)
+  - [Travel Search](#travel-search-service)
+- [Automation Examples](#automation-examples)
+- [Dashboard & Lovelace Cards](#dashboard--lovelace-cards)
+- [Operators](#operators)
+- [API Documentation](#api-documentation)
 
-## Dashboard cards
-There's also a couple of Lovelace dashboard cards to use as companions to this integration:
-- [Timetable Lovelace Dashboard custom card](https://github.com/MrSjodin/HomeAssistant_Trafiklab_Timetable_Card)
-- [Travel Search Lovelace Dashboard custom card](https://github.com/MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card)
+---
 
-## API and Integration Features
+## Features
 
-- **Real-time departures and arrivals**: Get live realtime departure and arrival information from any Trafiklab covered stop in Sweden
-- **Resrobot end-to-end travel search (new in v0.6.0)**: Trip planning between origin and destination (stop ID or coordinates)
+- **Real-time departures and arrivals**: Live departure and arrival information from any Trafiklab-covered stop in Sweden
+- **Resrobot end-to-end travel search**: Trip planning between origin and destination (stop ID, coordinates, stop name, HA zone, or person entity)
 - **Line filtering**: Monitor specific lines by filtering with comma-separated line numbers, per sensor
 - **Destination filtering**: Filter by (substring) text match of destination(s) at a stop (useful for busy stops), per sensor
 - **Configurable time window**: Set how many minutes ahead to search (1-1440 minutes), per sensor
-- **Maximum trip duration filter (new in v0.7.0)**: For Travel Search sensors, exclude trips whose total duration exceeds a configurable limit (1-1440 minutes). Leave empty for no limit. Backward compatible — existing config entries without this setting are unaffected.
-- **Transport mode filtering (new in v0.8.0)**: Filter results by one or more transport categories — Bus, Metro, Train, Tram, or Boat/Ferry — for both Realtime and Travel Search sensors. Leave empty to include all modes.
-- **Multiple transport modes**: Support for buses, trains, metro, trams, and boats/ferries
+- **Maximum trip duration filter**: For Travel Search sensors, exclude trips longer than a configurable limit (1-1440 minutes)
+- **Transport mode filtering**: Filter by transport category — Bus, Metro, Train, Tram, or Boat/Ferry — for both Realtime and Travel Search sensors
 - **Flexible sensor configuration**: Create separate sensors for departures and arrivals
-- **Stop lookup service**: Search for the stop ID by it's name using Home Assistant service
-- **Config flow**: Easy setup through the Home Assistant UI with step-by-step configuration
+- **Stop lookup service**: Find stop IDs by name using a Home Assistant service call
+- **Update now service**: Force an immediate data refresh for one or all sensors — by service call or via the entry's button
+- **Ad-hoc travel search service**: Query Resrobot for a journey on-demand without a permanent sensor, using stop IDs, coordinates, stop names, HA zones, or person/device_tracker entities
+- **Config flow**: Easy setup through the Home Assistant UI
 - **Multi-language support**: English and Swedish translations
-- **Nationwide coverage**: Covers all public transport operators in Sweden that are a part of Trafiklab API. 
-
-The integration uses the newer **Trafiklab Realtime APIs** - see [Trafiklab Realtime API webpage](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/) for more information.
+- **Nationwide coverage**: All public transport operators in Sweden covered by Trafiklab
 
 
 ## Installation
@@ -51,6 +59,19 @@ The integration uses the newer **Trafiklab Realtime APIs** - see [Trafiklab Real
 
 1. Copy the `custom_components/trafiklab` folder to your Home Assistant `custom_components` directory
 2. Restart Home Assistant
+
+## Finding Your Stop ID
+
+Before you can configure any sensor, you need the **stop ID** for your location. Use the built-in `trafiklab.stop_lookup` service to find it — see [Stop ID Lookup Service](#stop-id-lookup-service) for full details.
+
+**Quick steps:**
+1. If you have no Trafiklab config entries yet, add this one-line stub to `configuration.yaml` and restart:
+   ```yaml
+   trafiklab:
+   ```
+2. Open **Developer Tools → Services**, select `trafiklab.stop_lookup`
+3. Enter your **Realtime API key** and a search string (your stop or town name)
+4. Copy the `id` value from the response — that is your **Stop ID**
 
 ## Configuration
 
@@ -289,7 +310,7 @@ If the field is left empty, updates always occur. On template errors, the integr
 - Negative numbers indicate past departures (useful for detecting delays)
 - `null`/`unavailable` indicates no data available
 
-### Automation Examples
+## Automation Examples
 
 #### Basic Departure Notification
 ```yaml
@@ -398,35 +419,41 @@ automation:
             in {{ states('sensor.my_stop_next_departure') }} minutes!
 ```
 
+## Services
+
 ### Stop ID Lookup Service
 
-There are basically two ways of lookup the Stop ID. You can go directly to [Trafiklab API](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/openapi-specification/) where you can use the function to try out the Stop lookup API. Enter your API key and search string to get a response back.
+Before you can configure a departure, arrival, or travel search sensor you need the **stop ID** for your location. The `trafiklab.stop_lookup` service lets you find it directly from Home Assistant without leaving the UI.
 
-The other way is to use the integration provided service to search for stops by name. Please note that the service only registers in Home Assistant if either:
-1. You have at least one Trafiklab config entry; OR
-2. You add an (optional) empty YAML stub in configuration.yaml:
+#### Getting started — before your first sensor
+
+The service registers as soon as the integration is loaded. If you haven't added any Trafiklab config entry yet, add a one-line YAML stub so the integration loads on startup:
 
 ```yaml
+# configuration.yaml
 trafiklab:
 ```
 
-When you have entered the YAML stub and restarted Home Assistant, you can now call the service:
+Restart Home Assistant, then open **Developer Tools → Services**, search for `trafiklab.stop_lookup`, and call it with your Realtime API key and a search string.
+
+#### Calling the service
 
 ```yaml
 service: trafiklab.stop_lookup
 data:
-  api_key: "your_api_key"
+  api_key: "your_realtime_api_key"  # required the first time; optional once a departure/arrival sensor exists
   search_query: "Stockholm"
 ```
 
-#### Service Response
+**`api_key`** is your [Trafiklab Realtime API key](https://www.trafiklab.se/). Once you have at least one departure or arrival sensor configured, the key is resolved automatically and you can omit this field entirely.
 
-The service returns data directly in the Services panel:
+#### Response
+
 ```yaml
 search_query: "Stockholm"
 total_stops: 3
 stops_found:
-  - id: "740098000" # <-- This is what you'll use as Stop ID when setting up a departure or arrival sensor
+  - id: "740098000"     # ← copy this value as the Stop ID when setting up a sensor
     name: "Stockholm"
     area_type: "META_STOP"
     transport_modes: ["BUS", "TRAIN", "TRAM", "METRO"]
@@ -438,27 +465,188 @@ stops_found:
         lon: 18.054943
 ```
 
-Events are not currently emitted; use the direct service response.
+Use the `id` value from `stops_found` as the **Stop ID** (or **Origin / Destination** for Travel Search) when creating a sensor. The area-level ID (e.g. `740098000`) covers all platforms at that location and is usually what you want.
 
-### Automation with Stop Lookup
+> **Tip:** If your search returns many results, add more of the stop name to narrow it down — e.g. `"Stockholms centralstation"` instead of `"Stockholm"`.
+
+---
+
+### Update Now Service
+
+Force an immediate data refresh for one or all configured sensors. Useful in automations that react to events (arrivals home, alarm clock, etc.) and need fresh data right away.
+
+```yaml
+# Refresh all Trafiklab sensors at once
+service: trafiklab.update_now
+```
+
+```yaml
+# Refresh a single sensor by its config entry ID
+service: trafiklab.update_now
+data:
+  config_entry_id: "your_entry_id"
+```
+
+The `config_entry_id` is shown in **Settings → Devices & Services → Trafiklab → (entry) → Info**. Omit it to refresh every active Trafiklab entry.
+
+#### Automation example
 
 ```yaml
 automation:
-  - alias: "Find stops and notify"
+  - alias: "Refresh departures when arriving home"
     trigger:
-      - platform: event
-        event_type: trafiklab_stop_lookup_result
+      - platform: state
+        entity_id: person.john
+        to: "home"
     action:
-      - service: notify.persistent_notification
-        data:
-          message: >
-            Found {{ event.data.stops_found | length }} stops for "{{ event.data.search_query }}":
-            {% for stop in event.data.stops_found[:5] %}
-            - {{ stop.name }} (ID: {{ stop.id }})
-            {% endfor %}
+      - service: trafiklab.update_now
 ```
 
-### Lovelace Card Examples
+---
+
+### Travel Search Service
+
+Query Resrobot for a journey on demand — no permanent sensor required. Returns normalised trips directly as a service response. Requires a **Resrobot API key** (separate from the Realtime key).
+
+The `api_key` is optional when you already have a Resrobot Travel Search sensor configured; the key is resolved automatically from it.
+
+#### Origin and destination types
+
+| `origin_type` / `destination_type` | `origin` / `destination` value | Notes |
+|---|---|---|
+| `stop_id` *(default)* | National stop ID, e.g. `"740000001"` | Use Stop Lookup to find IDs |
+| `coordinates` | `"lat,lon"`, e.g. `"59.330,18.059"` | Decimal degrees |
+| `name` | Free-text stop name, e.g. `"Stockholm C"` | First Resrobot match is used; resolved ID returned as `resolved_origin_id` / `resolved_destination_id` |
+| `zone` | HA zone name or entity ID, e.g. `"home"` or `"zone.work"` | Resolved coordinates returned as `resolved_origin_coords` / `resolved_destination_coords` |
+| `person` | HA person or device_tracker entity ID, e.g. `"person.john"` | Uses GPS attributes when available; falls back to the zone the person is currently in |
+
+#### Basic example — two stop IDs
+
+```yaml
+service: trafiklab.travel_search
+data:
+  origin: "740000001"
+  destination: "740098000"
+```
+
+#### Name resolution
+
+```yaml
+service: trafiklab.travel_search
+data:
+  origin: "Centralen"
+  origin_type: "name"
+  destination: "Odenplan"
+  destination_type: "name"
+```
+
+The response includes `resolved_origin_id` and `resolved_destination_id` with the national stop IDs that were used.
+
+#### Using a zone as destination
+
+```yaml
+service: trafiklab.travel_search
+data:
+  origin: "740000001"
+  destination: "home"         # resolves zone.home
+  destination_type: "zone"
+```
+
+Response includes `resolved_destination_coords`.
+
+#### Using current position as origin
+
+```yaml
+service: trafiklab.travel_search
+data:
+  origin: "person.john"      # uses GPS or falls back to zone coords
+  origin_type: "person"
+  destination: "740098000"
+```
+
+#### Full example with all options
+
+```yaml
+service: trafiklab.travel_search
+data:
+  api_key: "your_resrobot_api_key"   # optional — resolved from Resrobot sensor if omitted
+  origin: "person.john"
+  origin_type: "person"
+  destination: "home"
+  destination_type: "zone"
+  via: "740001234"                   # optional intermediate stop
+  max_walking_distance: 800          # metres (default 1000)
+  transport_modes:                   # empty = all modes
+    - train
+    - bus
+  max_trip_duration: 90              # exclude trips longer than 90 minutes
+```
+
+#### Service response
+
+```yaml
+total_trips: 2
+resolved_origin_coords: "59.340,18.055"   # present when origin_type is person or zone
+resolved_destination_coords: "59.329,18.068"
+trips:
+  - index: 0
+    duration_total: 42          # total minutes, null if times unparseable
+    legs:
+      - origin_name: "Nearest stop"
+        origin_time: "2026-05-03 14:30:00"
+        dest_name: "Stockholm C"
+        dest_time: "2026-05-03 15:00:00"
+        type: "Public Transport"
+        product: "SJ Regional"
+        direction: "Stockholm"
+        line_number: "42"
+        category: "Train"
+        duration: 30
+  - index: 1
+    duration_total: 55
+    legs: [ ... ]
+```
+
+If an error occurs (bad API key, unresolvable stop name, etc.) the response contains `trips: []`, `total_trips: 0`, and an `error` field with a description.
+
+#### Automation example — notify on journey options
+
+```yaml
+automation:
+  - alias: "Journey home options"
+    trigger:
+      - platform: time
+        at: "16:00:00"
+    action:
+      - service: trafiklab.travel_search
+        data:
+          origin: "person.john"
+          origin_type: "person"
+          destination: "home"
+          destination_type: "zone"
+          max_trip_duration: 60
+        response_variable: journey
+      - condition: template
+        value_template: "{{ journey.total_trips > 0 }}"
+      - service: notify.mobile_app_my_phone
+        data:
+          message: >
+            {{ journey.total_trips }} journey(s) home found.
+            Next departs at
+            {{ journey.trips[0].legs[0].origin_time }}.
+```
+
+---
+
+## Dashboard & Lovelace Cards
+
+There are companion dashboard cards designed for this integration:
+- [Timetable card](https://github.com/MrSjodin/HomeAssistant_Trafiklab_Timetable_Card) — shows upcoming departures/arrivals in a timetable layout
+- [Travel Search card](https://github.com/MrSjodin/HomeAssistant_Trafiklab_TravelSearch_Card) — shows journey results from a Travel Search sensor
+
+### Built-in Lovelace Card Examples
+
+The sensors also work with any standard HA card. Some examples:
 
 #### Basic Entity Card
 ```yaml
@@ -572,10 +760,11 @@ For current list of operators, please visit [Trafiklab Timetables page](https://
 
 This integration uses the following Trafiklab APIs and endpoints:
 
-- [Trafiklab Realtime APIs](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/)
-- [Trafiklab Timetables](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/timetables/) (for departures and arrivals)
-- [Trafiklab Stop Lookup](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/stop-lookup/) (for finding stops)
-- [Resrobot Travel Search](https://www.trafiklab.se/api/our-apis/resrobot-v21/) (via Trafiklab) for trip planning between origin and destination (separate API key)
+- [Trafiklab Realtime APIs](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/) — departures, arrivals, and stop lookup
+- [Trafiklab Timetables](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/timetables/) — departure and arrival boards
+- [Trafiklab Stop Lookup](https://www.trafiklab.se/api/our-apis/trafiklab-realtime-apis/stop-lookup/) — finding stops by name (used by the `stop_lookup` service)
+- [Resrobot v2.1 Travel Search](https://www.trafiklab.se/api/our-apis/resrobot-v21/) — trip planning between any two points in Sweden (used by Travel Search sensors and the `travel_search` service; requires a separate Resrobot API key)
+- [Resrobot v2.1 Stop Lookup](https://www.trafiklab.se/api/our-apis/resrobot-v21/stop-lookup/) — stop name resolution returning national stop IDs (used internally by the `travel_search` service when `origin_type` or `destination_type` is `"name"`)
 
 
 ## License
@@ -601,4 +790,4 @@ Developing isn't my day job - I'm taking care of this integration solely on my f
 - [Trafiklab](https://www.trafiklab.se/) for providing the excellent public transport API
 - Home Assistant community for excellent development documentation
 - [HASL developers](https://github.com/hasl-sensor/) for the integration that basically provided the idea behind this integration
-- Claude Sonnet 4, for help sort things out whenever I'm a little out on the deep waters... Like I said - developing isn't my day job
+- Claude Sonnet & friends, for being quite helpful sort things out whenever I'm a little out on the deep waters... Like I said - developing isn't my day job 

--- a/custom_components/trafiklab/api.py
+++ b/custom_components/trafiklab/api.py
@@ -14,6 +14,7 @@ from .const import (
     STOP_LOOKUP_ENDPOINT,
     RESROBOT_BASE_URL,
     RESROBOT_TRAVEL_SEARCH_ENDPOINT,
+    RESROBOT_LOCATION_ENDPOINT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -181,7 +182,7 @@ class TrafikLabApiClient:
             raise TrafikLabApiError(f"Request failed: {err}") from err
 
     async def search_stops(self, search_value: str) -> dict[str, Any]:
-        """Search for stops by name."""
+        """Search for stops by name using the Realtime API (returns local stop IDs)."""
         url = f"{API_BASE_URL}{STOP_LOOKUP_ENDPOINT}/{search_value}"
         params = {"key": self.api_key}
 
@@ -193,6 +194,36 @@ class TrafikLabApiClient:
             raise TrafikLabApiError("Request timed out") from err
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Request failed: {err}") from err
+
+    async def search_resrobot_stops(self, search_value: str, api_key: str) -> dict[str, Any]:
+        """Search for stops by name using Resrobot /location.name (returns national stop IDs).
+
+        Use this when the resolved stop ID will be passed to get_resrobot_travel_search.
+        Returns a dict with a ``StopLocation`` list, each entry having an ``extId``
+        field containing the national 9-digit stop ID (e.g. "740000001").
+        """
+        url = f"{RESROBOT_BASE_URL}{RESROBOT_LOCATION_ENDPOINT}"
+        params = {
+            "accessId": api_key,
+            "input": search_value,
+            "format": "json",
+        }
+        try:
+            async with self.session.get(url, params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    _LOGGER.debug("Resrobot location.name raw response for %r: %s", search_value, data)
+                    return data
+                response_text = await response.text()
+                if response.status == 403:
+                    raise TrafikLabApiError(f"Invalid Resrobot API key: {response_text}")
+                else:
+                    response.raise_for_status()
+                    return await response.json()
+        except asyncio.TimeoutError as err:
+            raise TrafikLabApiError("Resrobot location lookup timed out") from err
+        except aiohttp.ClientError as err:
+            raise TrafikLabApiError(f"Resrobot location lookup failed: {err}") from err
 
     async def validate_api_key(self, area_id: str = "740098000") -> bool:
         """Validate the API key by making a test request to Stockholm."""

--- a/custom_components/trafiklab/const.py
+++ b/custom_components/trafiklab/const.py
@@ -50,6 +50,7 @@ STOP_LOOKUP_ENDPOINT: Final = "/stops/name"
 # Resrobot API
 RESROBOT_BASE_URL: Final = "https://api.resrobot.se/v2.1"
 RESROBOT_TRAVEL_SEARCH_ENDPOINT: Final = "/trip"
+RESROBOT_LOCATION_ENDPOINT: Final = "/location.name"
 
 # Transport modes
 TRANSPORT_MODES = {
@@ -76,6 +77,7 @@ RESROBOT_PRODUCTS_MAP: dict[str, int] = {
 # Service names
 SERVICE_STOP_LOOKUP: Final = "stop_lookup"
 SERVICE_UPDATE_NOW: Final = "update_now"
+SERVICE_TRAVEL_SEARCH: Final = "travel_search"
 
 # Service fields
 ATTR_SEARCH_QUERY: Final = "search_query"

--- a/custom_components/trafiklab/sensor.py
+++ b/custom_components/trafiklab/sensor.py
@@ -274,7 +274,8 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             )
         return upcoming
 
-    def _normalize_resrobot_trips(self, trips_raw: Any, max_trip_duration: int | None = None) -> list[dict[str, Any]]:
+    @staticmethod
+    def _normalize_resrobot_trips(trips_raw: Any, max_trip_duration: int | None = None) -> list[dict[str, Any]]:
         """Normalize and sort ResRobot trips and their legs for attribute exposure.
 
         Returns a list of trips where each has a key "legs" which is a list of
@@ -538,3 +539,6 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             ",".join(direction_tokens) if direction_tokens else "*",
         )
         return filtered
+
+
+normalize_resrobot_trips = TrafikLabSensor._normalize_resrobot_trips

--- a/custom_components/trafiklab/services.yaml
+++ b/custom_components/trafiklab/services.yaml
@@ -4,11 +4,18 @@ stop_lookup:
   fields:
     api_key:
       name: API Key
-      description: Your Trafiklab API key
-      required: true
+      description: Your Trafiklab Realtime API key. Omit to use the key from a configured departure/arrival sensor.
+      required: false
       selector:
         text:
           type: password
+    config_entry_id:
+      name: Config entry ID
+      description: Specific Trafiklab config entry to take the API key from. Ignored when api_key is provided.
+      required: false
+      selector:
+        config_entry:
+          integration: trafiklab
     search_query:
       name: Search query
       description: Search string to find stops (minimum 1 character)
@@ -28,3 +35,103 @@ update_now:
       selector:
         config_entry:
           integration: trafiklab
+
+travel_search:
+  name: Travel search
+  description: Search for public transport journeys between two stops using Resrobot API
+  fields:
+    api_key:
+      name: API Key
+      description: Your Resrobot API key. Omit to use the key from a configured Resrobot travel search sensor.
+      required: false
+      selector:
+        text:
+          type: password
+    config_entry_id:
+      name: Config entry ID
+      description: Specific Trafiklab config entry to take the Resrobot API key from. Ignored when api_key is provided.
+      required: false
+      selector:
+        config_entry:
+          integration: trafiklab
+    origin:
+      name: Origin
+      description: Stop ID, coordinates ("lat,lon"), stop name, zone name (e.g. "home"), or person/device_tracker entity ID — depending on origin_type
+      required: true
+      example: "740000001"
+      selector:
+        text:
+    destination:
+      name: Destination
+      description: Stop ID, coordinates ("lat,lon"), stop name, zone name (e.g. "home"), or person/device_tracker entity ID — depending on destination_type
+      required: true
+      example: "740098000"
+      selector:
+        text:
+    origin_type:
+      name: Origin type
+      description: How to interpret the origin value
+      required: false
+      default: stop_id
+      example: "stop_id"
+      selector:
+        select:
+          options:
+            - stop_id
+            - coordinates
+            - name
+            - zone
+            - person
+    destination_type:
+      name: Destination type
+      description: How to interpret the destination value
+      required: false
+      default: stop_id
+      example: "stop_id"
+      selector:
+        select:
+          options:
+            - stop_id
+            - coordinates
+            - name
+            - zone
+            - person
+    via:
+      name: Via stop ID
+      description: Optional intermediate stop ID the journey must pass through
+      required: false
+      example: "740001234"
+      selector:
+        text:
+    max_walking_distance:
+      name: Max walking distance
+      description: Maximum walking distance in metres at origin and destination
+      required: false
+      default: 1000
+      selector:
+        number:
+          min: 0
+          max: 5000
+          unit_of_measurement: m
+    transport_modes:
+      name: Transport modes
+      description: Restrict to specific transport modes (empty means all modes)
+      required: false
+      selector:
+        select:
+          multiple: true
+          options:
+            - bus
+            - train
+            - metro
+            - tram
+            - boat
+    max_trip_duration:
+      name: Max trip duration
+      description: Filter out trips longer than this many minutes
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 1440
+          unit_of_measurement: min

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -81,7 +81,16 @@ def _resolve_realtime_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
     entry_id: str | None = call_data.get("config_entry_id")
     if entry_id:
         coordinator = domain_data.get(entry_id)
-        return coordinator.entry.data.get(CONF_API_KEY) if coordinator else None
+        if coordinator is None:
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' was not found for {DOMAIN}."
+            )
+        if coordinator.entry.data.get(CONF_SENSOR_TYPE) not in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' is not a departure or arrival entry — "
+                "only departure/arrival entries carry a Realtime API key."
+            )
+        return coordinator.entry.data.get(CONF_API_KEY)
     for coordinator in domain_data.values():
         if coordinator.entry.data.get(CONF_SENSOR_TYPE) in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
             return coordinator.entry.data.get(CONF_API_KEY)

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -388,25 +388,35 @@ def async_setup_services(hass: HomeAssistant) -> None:
                         destination_type = "stop_id"
                         destination = resolved_destination
 
-                    products: int | None = None
+                    known_transport_modes = []
                     if transport_modes:
-                        known = [m for m in transport_modes if m in RESROBOT_PRODUCTS_MAP]
-                        if known:
-                            products = sum(RESROBOT_PRODUCTS_MAP[m] for m in known)
+                        known_transport_modes = [
+                            mode for mode in transport_modes if mode in RESROBOT_PRODUCTS_MAP
+                        ]
 
-                    result = await client.get_resrobot_travel_search(
-                        api_key,
-                        origin_type,
-                        origin,
-                        destination_type,
-                        destination,
-                        via,
-                        "",
-                        max_walking_distance,
-                        products,
-                    )
+                    product_requests: list[int | None]
+                    if known_transport_modes:
+                        product_requests = [
+                            RESROBOT_PRODUCTS_MAP[mode] for mode in known_transport_modes
+                        ]
+                    else:
+                        product_requests = [None]
 
-                    trips_raw = (result or {}).get("Trip") or []
+                    trips_raw: list[dict[str, Any]] = []
+                    for products in product_requests:
+                        result = await client.get_resrobot_travel_search(
+                            api_key,
+                            origin_type,
+                            origin,
+                            destination_type,
+                            destination,
+                            via,
+                            "",
+                            max_walking_distance,
+                            products,
+                        )
+                        trips_raw.extend((result or {}).get("Trip") or [])
+
                     trips = normalize_resrobot_trips(trips_raw, max_trip_duration)
                     response.update({"trips": trips, "total_trips": len(trips)})
                     return response

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -137,7 +137,7 @@ def _resolve_zone_coordinates(hass: HomeAssistant, value: str) -> str | None:
 
     # 2. Slugified match (handles multi-word names like "My Home" → zone.my_home)
     if state is None:
-        slug = re.sub(r"[^a-z0-9_]", "_", re.sub(r"\s+", "_", stripped.lower()))
+        slug = re.sub(r"[^a-z0-9]+", "_", stripped.lower()).strip("_")
         slugged = slug if slug.startswith("zone.") else f"zone.{slug}"
         if slugged != normalized:
             state = hass.states.get(slugged)

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import voluptuous as vol
@@ -119,13 +120,37 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
 def _resolve_zone_coordinates(hass: HomeAssistant, value: str) -> str | None:
     """Resolve a zone name or entity_id to a 'lat,lon' string.
 
-    Accepts ``"home"``, ``"Home"``, or ``"zone.home"`` — all normalised the same way.
+    Resolution order:
+    1. Direct lowercase match: ``"home"`` → ``zone.home``, ``"zone.home"`` → ``zone.home``.
+    2. Slugified match: ``"My Home"`` → ``zone.my_home`` (spaces/special chars → underscores).
+    3. Friendly-name scan: case-insensitive match on the zone's ``friendly_name`` attribute.
+
     Returns ``None`` if the zone entity does not exist or has no location attributes.
     """
-    normalized = value.strip().lower()
+    stripped = value.strip()
+
+    # 1. Direct lowercase match (handles "home", "Home", "zone.home")
+    normalized = stripped.lower()
     if not normalized.startswith("zone."):
         normalized = f"zone.{normalized}"
     state = hass.states.get(normalized)
+
+    # 2. Slugified match (handles multi-word names like "My Home" → zone.my_home)
+    if state is None:
+        slug = re.sub(r"[^a-z0-9_]", "_", re.sub(r"\s+", "_", stripped.lower()))
+        slugged = slug if slug.startswith("zone.") else f"zone.{slug}"
+        if slugged != normalized:
+            state = hass.states.get(slugged)
+
+    # 3. Friendly-name scan (handles names with accents or that differ from the entity slug)
+    if state is None:
+        lower = stripped.lower()
+        for zone_state in hass.states.async_all("zone"):
+            friendly = (zone_state.attributes.get("friendly_name") or "").lower()
+            if friendly == lower:
+                state = zone_state
+                break
+
     if state is None:
         return None
     lat = state.attributes.get("latitude")

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -121,10 +121,10 @@ def _validate_coordinates(value: str) -> bool:
     """Return True when *value* is a valid ``'lat,lon'`` string."""
     try:
         lat, lon = value.split(",")
-        float(lat)
-        float(lon)
+        _lat = float(lat)
+        _lon = float(lon)
         return True
-    except Exception:
+    except (ValueError, AttributeError):
         return False
 
 

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -15,15 +15,31 @@ from .const import (
     DOMAIN,
     SERVICE_STOP_LOOKUP,
     SERVICE_UPDATE_NOW,
+    SERVICE_TRAVEL_SEARCH,
     CONF_API_KEY,
+    CONF_ORIGIN,
+    CONF_ORIGIN_TYPE,
+    CONF_DESTINATION,
+    CONF_DESTINATION_TYPE,
+    CONF_VIA,
+    CONF_MAX_WALKING_DISTANCE,
+    CONF_MAX_TRIP_DURATION,
+    CONF_TRANSPORT_MODES,
     ATTR_SEARCH_QUERY,
     ATTR_STOPS_FOUND,
+    RESROBOT_PRODUCTS_MAP,
+    CONF_SENSOR_TYPE,
+    SENSOR_TYPE_DEPARTURE,
+    SENSOR_TYPE_ARRIVAL,
+    SENSOR_TYPE_RESROBOT,
 )
+from .sensor import normalize_resrobot_trips
 
 _LOGGER = logging.getLogger(__name__)
 
 STOP_LOOKUP_SCHEMA = vol.Schema({
-    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_API_KEY): cv.string,
+    vol.Optional("config_entry_id"): cv.string,
     vol.Required(ATTR_SEARCH_QUERY): cv.string,
 })
 
@@ -31,18 +47,147 @@ UPDATE_NOW_SCHEMA = vol.Schema({
     vol.Optional("config_entry_id"): cv.string,
 })
 
+TRAVEL_SEARCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_API_KEY): cv.string,
+    vol.Optional("config_entry_id"): cv.string,
+    vol.Required(CONF_ORIGIN): cv.string,
+    vol.Required(CONF_DESTINATION): cv.string,
+    vol.Optional(CONF_ORIGIN_TYPE, default="stop_id"): vol.In(["stop_id", "coordinates", "name", "zone", "person"]),
+    vol.Optional(CONF_DESTINATION_TYPE, default="stop_id"): vol.In(["stop_id", "coordinates", "name", "zone", "person"]),
+    vol.Optional(CONF_VIA, default=""): cv.string,
+    vol.Optional(CONF_MAX_WALKING_DISTANCE, default=1000): vol.All(vol.Coerce(int), vol.Range(min=0)),
+    vol.Optional(CONF_TRANSPORT_MODES, default=list): vol.All(
+        cv.ensure_list,
+        [vol.In(list(RESROBOT_PRODUCTS_MAP.keys()))],
+    ),
+    vol.Optional(CONF_MAX_TRIP_DURATION, default=None): vol.Any(
+        None, vol.All(vol.Coerce(int), vol.Range(min=1, max=1440))
+    ),
+})
+
+
+def _resolve_realtime_api_key(hass: HomeAssistant, call_data: dict) -> str | None:
+    """Resolve a Realtime API key for the stop-lookup / departure / arrival APIs.
+
+    Resolution order:
+      1. Explicit ``api_key`` in call_data
+      2. Key from the entry identified by ``config_entry_id`` in call_data
+      3. Key from the first departure or arrival config entry in hass.data
+    """
+    if key := call_data.get(CONF_API_KEY):
+        return key
+    domain_data: dict = hass.data.get(DOMAIN, {})
+    entry_id: str | None = call_data.get("config_entry_id")
+    if entry_id:
+        coordinator = domain_data.get(entry_id)
+        return coordinator.entry.data.get(CONF_API_KEY) if coordinator else None
+    for coordinator in domain_data.values():
+        if coordinator.entry.data.get(CONF_SENSOR_TYPE) in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
+            return coordinator.entry.data.get(CONF_API_KEY)
+    return None
+
+
+def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | None:
+    """Resolve a Resrobot API key for the travel-search API.
+
+    Resolution order:
+      1. Explicit ``api_key`` in call_data
+      2. Key from the entry identified by ``config_entry_id`` in call_data
+      3. Key from the first Resrobot travel_search config entry in hass.data
+    """
+    if key := call_data.get(CONF_API_KEY):
+        return key
+    domain_data: dict = hass.data.get(DOMAIN, {})
+    entry_id: str | None = call_data.get("config_entry_id")
+    if entry_id:
+        coordinator = domain_data.get(entry_id)
+        return coordinator.entry.data.get(CONF_API_KEY) if coordinator else None
+    for coordinator in domain_data.values():
+        if coordinator.entry.data.get(CONF_SENSOR_TYPE) == SENSOR_TYPE_RESROBOT:
+            return coordinator.entry.data.get(CONF_API_KEY)
+    return None
+
+
+def _resolve_zone_coordinates(hass: HomeAssistant, value: str) -> str | None:
+    """Resolve a zone name or entity_id to a 'lat,lon' string.
+
+    Accepts ``"home"``, ``"Home"``, or ``"zone.home"`` — all normalised the same way.
+    Returns ``None`` if the zone entity does not exist or has no location attributes.
+    """
+    normalized = value.strip().lower()
+    if not normalized.startswith("zone."):
+        normalized = f"zone.{normalized}"
+    state = hass.states.get(normalized)
+    if state is None:
+        return None
+    lat = state.attributes.get("latitude")
+    lon = state.attributes.get("longitude")
+    if lat is None or lon is None:
+        return None
+    return f"{lat},{lon}"
+
+
+def _resolve_person_coordinates(hass: HomeAssistant, entity_id: str) -> str | None:
+    """Resolve a person or device_tracker entity to a 'lat,lon' string.
+
+    Tries direct GPS attributes first (set when the device reports location).
+    Falls back to the zone that the entity's state names (e.g. state = 'home').
+    Returns ``None`` if neither source is available.
+    """
+    state = hass.states.get(entity_id)
+    if state is None:
+        return None
+    lat = state.attributes.get("latitude")
+    lon = state.attributes.get("longitude")
+    if lat is not None and lon is not None:
+        return f"{lat},{lon}"
+    # Fallback: entity is in a known zone (state == zone name)
+    return _resolve_zone_coordinates(hass, state.state)
+
+
+def _extract_resrobot_stops(stop_result: dict) -> list[dict]:
+    """Extract a normalised stop list from a Resrobot /location.name response.
+
+    Handles two known response shapes:
+      - ``{"StopLocation": [...]}``  (classic Hafas)
+      - ``{"stopLocationOrCoordLocation": [...]}``  (newer Hafas)
+    Also handles the case where the API returns a single dict instead of a list.
+    """
+    raw = (
+        (stop_result or {}).get("StopLocation")
+        or (stop_result or {}).get("stopLocationOrCoordLocation")
+        or []
+    )
+    if isinstance(raw, dict):
+        raw = [raw]
+    # stopLocationOrCoordLocation entries are wrapped: {"StopLocation": {...}}
+    stops: list[dict] = []
+    for item in raw:
+        if isinstance(item, dict) and "StopLocation" in item:
+            stops.append(item["StopLocation"])
+        elif isinstance(item, dict):
+            stops.append(item)
+    return stops
+
 
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services for Trafiklab."""
     _LOGGER.debug("[Trafiklab] async_setup_services invoked")
-    if hass.services.has_service(DOMAIN, SERVICE_STOP_LOOKUP):
-        _LOGGER.debug("[Trafiklab] Service %s.%s already registered - skipping", DOMAIN, SERVICE_STOP_LOOKUP)
-        return
 
     async def handle_stop_lookup(call: ServiceCall) -> dict[str, Any]:
         """Handle stop lookup service call."""
-        api_key = call.data[CONF_API_KEY]
         search_query = call.data[ATTR_SEARCH_QUERY]
+        api_key = _resolve_realtime_api_key(hass, call.data)
+        if not api_key:
+            return {
+                "search_query": search_query,
+                "stops_found": [],
+                "total_stops": 0,
+                "error": (
+                    "No Realtime API key available — add a departure or arrival sensor "
+                    "or pass api_key explicitly"
+                ),
+            }
 
         session = async_get_clientsession(hass)
         async with TrafikLabApiClient(api_key, session=session) as client:
@@ -128,8 +273,151 @@ def async_setup_services(hass: HomeAssistant) -> None:
     )
     _LOGGER.info("[Trafiklab] Registered service %s.%s", DOMAIN, SERVICE_UPDATE_NOW)
 
+    if not hass.services.has_service(DOMAIN, SERVICE_TRAVEL_SEARCH):
+
+        async def handle_travel_search(call: ServiceCall) -> dict[str, Any]:
+            """Handle travel search service call."""
+            api_key = _resolve_resrobot_api_key(hass, call.data)
+            if not api_key:
+                return {
+                    "trips": [],
+                    "total_trips": 0,
+                    "error": (
+                        "No Resrobot API key available — add a Resrobot travel search sensor "
+                        "or pass api_key explicitly"
+                    ),
+                }
+            origin: str = call.data[CONF_ORIGIN]
+            destination: str = call.data[CONF_DESTINATION]
+            origin_type: str = call.data.get(CONF_ORIGIN_TYPE, "stop_id")
+            destination_type: str = call.data.get(CONF_DESTINATION_TYPE, "stop_id")
+            via: str = call.data.get(CONF_VIA, "") or ""
+            max_walking_distance: int = call.data.get(CONF_MAX_WALKING_DISTANCE, 1000)
+            transport_modes: list[str] = call.data.get(CONF_TRANSPORT_MODES) or []
+            max_trip_duration: int | None = call.data.get(CONF_MAX_TRIP_DURATION)
+
+            response: dict[str, Any] = {}
+            session = async_get_clientsession(hass)
+            # Name resolution uses the Resrobot /location.name endpoint (same key,
+            # same client) so the returned extId is already a national stop ID.
+            async with TrafikLabApiClient(api_key, session=session) as client:
+                try:
+                    if origin_type == "zone":
+                        coords = _resolve_zone_coordinates(hass, origin)
+                        if coords is None:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve zone '{origin}' — zone entity not found or has no location",
+                            }
+                        response["resolved_origin_coords"] = coords
+                        origin = coords
+                        origin_type = "coordinates"
+
+                    if origin_type == "person":
+                        coords = _resolve_person_coordinates(hass, origin)
+                        if coords is None:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve person/device_tracker location for '{origin}'",
+                            }
+                        response["resolved_origin_coords"] = coords
+                        origin = coords
+                        origin_type = "coordinates"
+
+                    if destination_type == "zone":
+                        coords = _resolve_zone_coordinates(hass, destination)
+                        if coords is None:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve zone '{destination}' — zone entity not found or has no location",
+                            }
+                        response["resolved_destination_coords"] = coords
+                        destination = coords
+                        destination_type = "coordinates"
+
+                    if destination_type == "person":
+                        coords = _resolve_person_coordinates(hass, destination)
+                        if coords is None:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve person/device_tracker location for '{destination}'",
+                            }
+                        response["resolved_destination_coords"] = coords
+                        destination = coords
+                        destination_type = "coordinates"
+
+                    if origin_type == "name":
+                        stop_result = await client.search_resrobot_stops(origin, api_key)
+                        stops = _extract_resrobot_stops(stop_result)
+                        if not stops:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve origin stop name: {origin}",
+                            }
+                        resolved_origin = stops[0].get("extId") or stops[0].get("id", "")
+                        response["resolved_origin_id"] = resolved_origin
+                        origin_type = "stop_id"
+                        origin = resolved_origin
+
+                    if destination_type == "name":
+                        stop_result = await client.search_resrobot_stops(destination, api_key)
+                        stops = _extract_resrobot_stops(stop_result)
+                        if not stops:
+                            return {
+                                "trips": [],
+                                "total_trips": 0,
+                                "error": f"Could not resolve destination stop name: {destination}",
+                            }
+                        resolved_destination = stops[0].get("extId") or stops[0].get("id", "")
+                        response["resolved_destination_id"] = resolved_destination
+                        destination_type = "stop_id"
+                        destination = resolved_destination
+
+                    products: int | None = None
+                    if transport_modes:
+                        known = [m for m in transport_modes if m in RESROBOT_PRODUCTS_MAP]
+                        if known:
+                            products = sum(RESROBOT_PRODUCTS_MAP[m] for m in known)
+
+                    result = await client.get_resrobot_travel_search(
+                        api_key,
+                        origin_type,
+                        origin,
+                        destination_type,
+                        destination,
+                        via,
+                        "",
+                        max_walking_distance,
+                        products,
+                    )
+
+                    trips_raw = (result or {}).get("Trip") or []
+                    trips = normalize_resrobot_trips(trips_raw, max_trip_duration)
+                    response.update({"trips": trips, "total_trips": len(trips)})
+                    return response
+
+                except Exception as err:
+                    _LOGGER.error("Error during travel search: %s", err)
+                    response.update({"trips": [], "total_trips": 0, "error": str(err)})
+                    return response
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            handle_travel_search,
+            schema=TRAVEL_SEARCH_SCHEMA,
+            supports_response=True,
+        )
+        _LOGGER.info("[Trafiklab] Registered service %s.%s", DOMAIN, SERVICE_TRAVEL_SEARCH)
+
 
 def async_remove_services(hass: HomeAssistant) -> None:
     """Remove services for Trafiklab."""
     hass.services.async_remove(DOMAIN, SERVICE_STOP_LOOKUP)
     hass.services.async_remove(DOMAIN, SERVICE_UPDATE_NOW)
+    hass.services.async_remove(DOMAIN, SERVICE_TRAVEL_SEARCH)

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -101,7 +101,15 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
     entry_id: str | None = call_data.get("config_entry_id")
     if entry_id:
         coordinator = domain_data.get(entry_id)
-        return coordinator.entry.data.get(CONF_API_KEY) if coordinator else None
+        if coordinator is None:
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' was not found for {DOMAIN}."
+            )
+        if coordinator.entry.data.get(CONF_SENSOR_TYPE) != SENSOR_TYPE_RESROBOT:
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' is not a Resrobot travel-search entry."
+            )
+        return coordinator.entry.data.get(CONF_API_KEY)
     for coordinator in domain_data.values():
         if coordinator.entry.data.get(CONF_SENSOR_TYPE) == SENSOR_TYPE_RESROBOT:
             return coordinator.entry.data.get(CONF_API_KEY)

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -117,6 +117,17 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
     return None
 
 
+def _validate_coordinates(value: str) -> bool:
+    """Return True when *value* is a valid ``'lat,lon'`` string."""
+    try:
+        lat, lon = value.split(",")
+        float(lat)
+        float(lon)
+        return True
+    except Exception:
+        return False
+
+
 def _resolve_zone_coordinates(hass: HomeAssistant, value: str) -> str | None:
     """Resolve a zone name or entity_id to a 'lat,lon' string.
 
@@ -426,6 +437,28 @@ def async_setup_services(hass: HomeAssistant) -> None:
                         known_transport_modes = [
                             mode for mode in transport_modes if mode in RESROBOT_PRODUCTS_MAP
                         ]
+
+                    # Validate coordinates now that all resolution is done.
+                    # Zone/person resolution already produces valid 'lat,lon' strings,
+                    # but user-supplied coordinates must be checked explicitly.
+                    if origin_type == "coordinates" and not _validate_coordinates(origin):
+                        return {
+                            "trips": [],
+                            "total_trips": 0,
+                            "error": (
+                                f"Invalid coordinates for origin: '{origin}' "
+                                "— expected 'lat,lon' (e.g. '59.33,18.07')"
+                            ),
+                        }
+                    if destination_type == "coordinates" and not _validate_coordinates(destination):
+                        return {
+                            "trips": [],
+                            "total_trips": 0,
+                            "error": (
+                                f"Invalid coordinates for destination: '{destination}' "
+                                "— expected 'lat,lon' (e.g. '59.33,18.07')"
+                            ),
+                        }
 
                     product_requests: list[int | None]
                     if known_transport_modes:

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -152,21 +152,31 @@ def _extract_resrobot_stops(stop_result: dict) -> list[dict]:
       - ``{"StopLocation": [...]}``  (classic Hafas)
       - ``{"stopLocationOrCoordLocation": [...]}``  (newer Hafas)
     Also handles the case where the API returns a single dict instead of a list.
+
+    Only actual stop objects are returned. In particular,
+    ``stopLocationOrCoordLocation`` may contain wrappers like
+    ``{"CoordLocation": {...}}`` which must not be treated as stops.
     """
-    raw = (
-        (stop_result or {}).get("StopLocation")
-        or (stop_result or {}).get("stopLocationOrCoordLocation")
-        or []
-    )
-    if isinstance(raw, dict):
-        raw = [raw]
-    # stopLocationOrCoordLocation entries are wrapped: {"StopLocation": {...}}
+    result = stop_result or {}
     stops: list[dict] = []
-    for item in raw:
-        if isinstance(item, dict) and "StopLocation" in item:
-            stops.append(item["StopLocation"])
-        elif isinstance(item, dict):
+
+    raw_stops = result.get("StopLocation") or []
+    if isinstance(raw_stops, dict):
+        raw_stops = [raw_stops]
+    for item in raw_stops:
+        if isinstance(item, dict):
             stops.append(item)
+
+    raw_mixed_locations = result.get("stopLocationOrCoordLocation") or []
+    if isinstance(raw_mixed_locations, dict):
+        raw_mixed_locations = [raw_mixed_locations]
+    for item in raw_mixed_locations:
+        if not isinstance(item, dict):
+            continue
+        stop_location = item.get("StopLocation")
+        if isinstance(stop_location, dict):
+            stops.append(stop_location)
+
     return stops
 
 

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -437,7 +437,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
 
 def async_remove_services(hass: HomeAssistant) -> None:
-    """Remove services for Trafiklab."""
+    """Remove services for Trafiklab.
+
+    ``travel_search`` is intentionally left registered because it can operate
+    without any loaded config entry when the caller supplies an explicit API
+    key (and it is also available from the YAML stub setup path). Removing it
+    when the last entry is unloaded makes the ad-hoc service disappear until
+    Home Assistant restarts.
+    """
     hass.services.async_remove(DOMAIN, SERVICE_STOP_LOOKUP)
     hass.services.async_remove(DOMAIN, SERVICE_UPDATE_NOW)
-    hass.services.async_remove(DOMAIN, SERVICE_TRAVEL_SEARCH)

--- a/custom_components/trafiklab/translations/en.json
+++ b/custom_components/trafiklab/translations/en.json
@@ -125,7 +125,10 @@
     "origin_type": {
       "options": {
         "stop_id": "Stop ID",
-        "coordinates": "Coordinates (lat,lon)"
+        "coordinates": "Coordinates (lat,lon)",
+        "name": "Stop name",
+        "zone": "Home Assistant zone (e.g. Home)",
+        "person": "Person / Device tracker"
       }
     },
     "transport_modes": {

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -125,7 +125,10 @@
     "origin_type": {
       "options": {
         "stop_id": "Hållplats-ID",
-        "coordinates": "Koordinater (lat,lon)"
+        "coordinates": "Koordinater (lat,lon)",
+        "name": "Hållplatsnamn",
+        "zone": "Home Assistant-zon (t.ex. Hemma)",
+        "person": "Person / Enhetsspårare"
       }
     },
     "transport_modes": {

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -127,7 +127,7 @@
         "stop_id": "Hållplats-ID",
         "coordinates": "Koordinater (lat,lon)",
         "name": "Hållplatsnamn",
-        "zone": "Home Assistant-zon (t.ex. Hemma)",
+        "zone": "Home Assistant-zon (t.ex. home)",
         "person": "Person / Enhetsspårare"
       }
     },

--- a/tests/components/trafiklab/test_services.py
+++ b/tests/components/trafiklab/test_services.py
@@ -566,3 +566,77 @@ async def test_travel_search_person_no_location(hass: Any, setup_integration: bo
     assert response["trips"] == []
     assert response["total_trips"] == 0
     assert "person.unknown" in response["error"]
+
+
+# ---------------------------------------------------------------------------
+# Coordinate validation tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_travel_search_invalid_origin_coordinates(hass: Any, setup_integration: bool) -> None:
+    """origin_type='coordinates' with a malformed value returns a descriptive error."""
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TRAVEL_SEARCH,
+        {
+            "api_key": "k",
+            "origin": "not_a_coordinate",
+            "origin_type": "coordinates",
+            "destination": "740098000",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "Invalid coordinates for origin" in response["error"]
+    assert "not_a_coordinate" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_travel_search_invalid_destination_coordinates(hass: Any, setup_integration: bool) -> None:
+    """destination_type='coordinates' with a malformed value returns a descriptive error."""
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TRAVEL_SEARCH,
+        {
+            "api_key": "k",
+            "origin": "740000001",
+            "destination": "bad;input",
+            "destination_type": "coordinates",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "Invalid coordinates for destination" in response["error"]
+    assert "bad;input" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_travel_search_valid_coordinates_accepted(hass: Any, setup_integration: bool) -> None:
+    """Valid 'lat,lon' coordinates are accepted without error."""
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "59.3293,18.0686",
+                "origin_type": "coordinates",
+                "destination": "59.334,18.063",
+                "destination_type": "coordinates",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert "error" not in response
+    assert response["total_trips"] == 1

--- a/tests/components/trafiklab/test_services.py
+++ b/tests/components/trafiklab/test_services.py
@@ -353,6 +353,49 @@ async def test_stop_lookup_key_resolved_from_departure_entry(hass: HomeAssistant
     assert "error" not in response
 
 
+@pytest.mark.asyncio
+async def test_stop_lookup_rejects_unknown_config_entry_id(hass: HomeAssistant, setup_integration: bool) -> None:
+    """stop_lookup raises ServiceValidationError for an unknown config_entry_id."""
+    with pytest.raises(ServiceValidationError, match="not found"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_STOP_LOOKUP,
+            {"config_entry_id": "nonexistent-entry-id", "search_query": "central"},
+            blocking=True,
+            return_response=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_lookup_rejects_resrobot_config_entry_id(hass: HomeAssistant) -> None:
+    """stop_lookup raises ServiceValidationError when a Resrobot entry_id is supplied."""
+    from tests.components.trafiklab.const import ENTRY_DATA_RESROBOT, ENTRY_OPTIONS_DEFAULT
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA_RESROBOT,
+        options=ENTRY_OPTIONS_DEFAULT,
+        unique_id="test-stop-lookup-wrong-type",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data",
+        return_value={},
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError, match="not a departure or arrival entry"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_STOP_LOOKUP,
+            {"config_entry_id": entry.entry_id, "search_query": "central"},
+            blocking=True,
+            return_response=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Zone and person origin/destination tests
 # ---------------------------------------------------------------------------

--- a/tests/components/trafiklab/test_services.py
+++ b/tests/components/trafiklab/test_services.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.trafiklab.const import DOMAIN, SERVICE_STOP_LOOKUP, SERVICE_UPDATE_NOW
+from custom_components.trafiklab.const import DOMAIN, SERVICE_STOP_LOOKUP, SERVICE_UPDATE_NOW, SERVICE_TRAVEL_SEARCH
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
 
@@ -118,3 +118,395 @@ async def test_update_now_invalid_entry_id(hass: HomeAssistant, setup_integratio
             {"config_entry_id": "does-not-exist"},
             blocking=True,
         )
+
+_RESROBOT_TRIP = {
+    "Trip": [
+        {
+            "LegList": {
+                "Leg": [
+                    {
+                        "Origin": {"name": "Stop A", "date": "2099-12-31", "time": "10:00:00"},
+                        "Destination": {"name": "Stop B", "date": "2099-12-31", "time": "10:20:00"},
+                        "Product": {"name": "Bus 52", "num": "52"},
+                        "category": "BLT",
+                        "duration": "PT20M",
+                        "direction": "City",
+                        "idx": 1,
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_travel_search_with_stop_id(hass: Any, setup_integration: bool) -> None:
+    """Happy path: travel_search with stop_id origin and destination."""
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ):
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "740000001",
+                "destination": "740000002",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response["total_trips"] == 1
+    assert len(response["trips"]) == 1
+    leg = response["trips"][0]["legs"][0]
+    assert leg["origin_name"] == "Stop A"
+    assert leg["dest_name"] == "Stop B"
+    assert leg["duration"] == 20
+    assert "resolved_origin_id" not in response
+    assert "resolved_destination_id" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_with_name_resolution(hass: Any, setup_integration: bool) -> None:
+    """origin_type='name' and destination_type='name' resolve via search_resrobot_stops."""
+    mock_origin_result = {
+        "StopLocation": [
+            {"extId": "740000001", "name": "Centralen", "lat": "59.330", "lon": "18.059"},
+        ]
+    }
+    mock_dest_result = {
+        "StopLocation": [
+            {"extId": "740000002", "name": "Odenplan", "lat": "59.342", "lon": "18.049"},
+        ]
+    }
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.search_resrobot_stops",
+        side_effect=[mock_origin_result, mock_dest_result],
+    ) as mock_search, patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "Centralen",
+                "origin_type": "name",
+                "destination": "Odenplan",
+                "destination_type": "name",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    assert mock_search.call_count == 2
+    assert mock_trip.call_count == 1
+    assert response["resolved_origin_id"] == "740000001"
+    assert response["resolved_destination_id"] == "740000002"
+    assert response["total_trips"] == 1
+
+
+@pytest.mark.asyncio
+async def test_travel_search_empty_response(hass: Any, setup_integration: bool) -> None:
+    """Empty Trip list returns total_trips=0."""
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value={},
+    ):
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {"api_key": "k", "origin": "740000001", "destination": "740000002"},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_api_error(hass: Any, setup_integration: bool) -> None:
+    """API exception is caught and returned as error field."""
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        side_effect=Exception("network failure"),
+    ):
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {"api_key": "k", "origin": "740000001", "destination": "740000002"},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "network failure" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_travel_search_key_resolved_from_resrobot_entry(hass: HomeAssistant) -> None:
+    """Resrobot API key is resolved automatically from a Resrobot config entry."""
+    from tests.components.trafiklab.const import ENTRY_DATA_RESROBOT, ENTRY_OPTIONS_DEFAULT
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA_RESROBOT,
+        options=ENTRY_OPTIONS_DEFAULT,
+        unique_id="test-keyresolution-resrobot",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data",
+        return_value={},
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {"origin": "740000001", "destination": "740000002"},
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert response["total_trips"] == 1
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_no_key_no_entry_returns_error(hass: HomeAssistant, setup_integration: bool) -> None:
+    """No api_key and no Resrobot entry returns a descriptive error."""
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TRAVEL_SEARCH,
+        {"origin": "740000001", "destination": "740000002"},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "Resrobot API key" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_stop_lookup_key_resolved_from_departure_entry(hass: HomeAssistant) -> None:
+    """Realtime API key is resolved automatically from a departure config entry."""
+    from tests.components.trafiklab.const import ENTRY_DATA_DEPARTURE, ENTRY_OPTIONS_DEFAULT
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=ENTRY_DATA_DEPARTURE,
+        options=ENTRY_OPTIONS_DEFAULT,
+        unique_id="test-keyresolution-departure",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data",
+        return_value={},
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_api_result = {
+        "stop_groups": [
+            {
+                "id": "g1",
+                "name": "Centralen",
+                "area_type": "station",
+                "transport_modes": ["TRAIN"],
+                "average_daily_stop_times": 100,
+                "stops": [{"id": "s1", "name": "Centralen A", "lat": 59.0, "lon": 18.0}],
+            }
+        ]
+    }
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.search_stops",
+        return_value=mock_api_result,
+    ) as mock_search:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_STOP_LOOKUP,
+            {"search_query": "central"},
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_search.assert_called_once()
+    assert response["total_stops"] == 1
+    assert "error" not in response
+
+
+# ---------------------------------------------------------------------------
+# Zone and person origin/destination tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_travel_search_with_zone_origin(hass: Any, setup_integration: bool) -> None:
+    """origin_type='zone' resolves the zone entity to coordinates."""
+    hass.states.async_set(
+        "zone.home", "zoning", {"latitude": 59.3293, "longitude": 18.0686}
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "home",
+                "origin_type": "zone",
+                "destination": "740098000",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert response["resolved_origin_coords"] == "59.3293,18.0686"
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_with_zone_destination(hass: Any, setup_integration: bool) -> None:
+    """destination_type='zone' resolves the zone entity to coordinates."""
+    hass.states.async_set(
+        "zone.work", "zoning", {"latitude": 59.334, "longitude": 18.063}
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ):
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "740000001",
+                "destination": "Work",
+                "destination_type": "zone",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response["resolved_destination_coords"] == "59.334,18.063"
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_zone_not_found(hass: Any, setup_integration: bool) -> None:
+    """zone origin that does not exist returns an error field."""
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TRAVEL_SEARCH,
+        {
+            "api_key": "k",
+            "origin": "nonexistent_zone",
+            "origin_type": "zone",
+            "destination": "740098000",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "nonexistent_zone" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_travel_search_with_person_gps(hass: Any, setup_integration: bool) -> None:
+    """origin_type='person' uses GPS attributes directly."""
+    hass.states.async_set(
+        "person.john", "home", {"latitude": 59.340, "longitude": 18.055}
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "person.john",
+                "origin_type": "person",
+                "destination": "740098000",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert response["resolved_origin_coords"] == "59.34,18.055"
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_with_person_zone_fallback(hass: Any, setup_integration: bool) -> None:
+    """origin_type='person' falls back to zone coords when no GPS attributes."""
+    # Person has no lat/lon — state is "home" which is a zone
+    hass.states.async_set("person.jane", "home", {})
+    hass.states.async_set(
+        "zone.home", "zoning", {"latitude": 59.3293, "longitude": 18.0686}
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ):
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "person.jane",
+                "origin_type": "person",
+                "destination": "740098000",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    assert response["resolved_origin_coords"] == "59.3293,18.0686"
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_person_no_location(hass: Any, setup_integration: bool) -> None:
+    """person entity with no GPS and no matching zone returns an error."""
+    hass.states.async_set("person.unknown", "not_home", {})
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TRAVEL_SEARCH,
+        {
+            "api_key": "k",
+            "origin": "person.unknown",
+            "origin_type": "person",
+            "destination": "740098000",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["trips"] == []
+    assert response["total_trips"] == 0
+    assert "person.unknown" in response["error"]

--- a/tests/components/trafiklab/test_services.py
+++ b/tests/components/trafiklab/test_services.py
@@ -413,7 +413,63 @@ async def test_travel_search_with_zone_destination(hass: Any, setup_integration:
 
 
 @pytest.mark.asyncio
-async def test_travel_search_zone_not_found(hass: Any, setup_integration: bool) -> None:
+async def test_travel_search_zone_multiword_slugified(hass: Any, setup_integration: bool) -> None:
+    """origin_type='zone' with a multi-word name resolves via slugify (e.g. 'My Home' → zone.my_home)."""
+    hass.states.async_set(
+        "zone.my_home", "zoning", {"latitude": 59.3293, "longitude": 18.0686}
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "My Home",
+                "origin_type": "zone",
+                "destination": "740098000",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert response["resolved_origin_coords"] == "59.3293,18.0686"
+    assert "error" not in response
+
+
+@pytest.mark.asyncio
+async def test_travel_search_zone_by_friendly_name(hass: Any, setup_integration: bool) -> None:
+    """origin_type='zone' resolves via friendly_name scan for accented/non-slug names."""
+    hass.states.async_set(
+        "zone.home", "zoning",
+        {"latitude": 59.3293, "longitude": 18.0686, "friendly_name": "Hemma"},
+    )
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        return_value=_RESROBOT_TRIP,
+    ) as mock_trip:
+        response = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TRAVEL_SEARCH,
+            {
+                "api_key": "k",
+                "origin": "Hemma",
+                "origin_type": "zone",
+                "destination": "740098000",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_trip.assert_called_once()
+    assert response["resolved_origin_coords"] == "59.3293,18.0686"
+    assert "error" not in response
+
+
+
     """zone origin that does not exist returns an error field."""
     response = await hass.services.async_call(
         DOMAIN,


### PR DESCRIPTION
- New service `travel_search` able to dynamically search for a travel from origins and to destinations based on:
  + The stop id, if known
  + The name of the stop (will catch first return)
  + A defined Home Assistant zone
  + A persons location

Meaning that a user, for example, can call a predefined service definition for searching for a trip from their location to e.g. `home`.

Fixes #48 