### PR TITLE
Add `platform` attribute to Resrobot sensors and search service

### DIFF
--- a/custom_components/trafiklab/config_flow.py
+++ b/custom_components/trafiklab/config_flow.py
@@ -52,6 +52,7 @@ from .const import (
     CONF_MAX_WALKING_DISTANCE,
     CONF_MAX_TRIP_DURATION,
     CONF_TRANSPORT_MODES,
+    CONF_INCLUDE_PLATFORM,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -266,6 +267,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional(CONF_TRANSPORT_MODES, default=[]): _TRANSPORT_MODES_SELECTOR,
             vol.Optional(CONF_REFRESH_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(vol.Coerce(int), vol.Range(min=MINIMUM_SCAN_INTERVAL, max=3600)),
             vol.Optional(CONF_TIME_WINDOW, default=DEFAULT_TIME_WINDOW): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+            vol.Optional(CONF_INCLUDE_PLATFORM, default=False): bool,
         })
 
         if user_input is not None:
@@ -315,6 +317,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_TRANSPORT_MODES: user_input.get(CONF_TRANSPORT_MODES, []),
                     "refresh_interval": refresh_interval,
                     "time_window": time_window,
+                    CONF_INCLUDE_PLATFORM: user_input.get(CONF_INCLUDE_PLATFORM, False),
                 }
                 # Unique ID should be stable and not include name which can change
                 unique_id = f"resrobot_{origin}_{destination}"
@@ -542,6 +545,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(CONF_TIME_WINDOW, default=DEFAULT_TIME_WINDOW): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=1440)
             ),
+            vol.Optional(CONF_INCLUDE_PLATFORM, default=False): bool,
         })
         current_values = {**self._entry.data, **self._entry.options}
         # Normalize transport_modes: old entries may lack the key, have None stored,

--- a/custom_components/trafiklab/const.py
+++ b/custom_components/trafiklab/const.py
@@ -26,6 +26,7 @@ CONF_AVOID: Final = "avoid"
 CONF_MAX_WALKING_DISTANCE: Final = "max_walking_distance"
 CONF_MAX_TRIP_DURATION: Final = "max_trip_duration"
 CONF_TRANSPORT_MODES: Final = "transport_modes"
+CONF_INCLUDE_PLATFORM: Final = "include_platform"
 
 
 # Sensor types

--- a/custom_components/trafiklab/const.py
+++ b/custom_components/trafiklab/const.py
@@ -27,6 +27,7 @@ CONF_MAX_WALKING_DISTANCE: Final = "max_walking_distance"
 CONF_MAX_TRIP_DURATION: Final = "max_trip_duration"
 CONF_TRANSPORT_MODES: Final = "transport_modes"
 CONF_INCLUDE_PLATFORM: Final = "include_platform"
+CONF_REALTIME_API_KEY: Final = "realtime_api_key"
 
 
 # Sensor types

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     CONF_API_KEY as _CONF_API_KEY,
 )
+from .api import TrafikLabApiClient
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
@@ -325,7 +326,6 @@ async def enrich_platform_for_trips(
     each covering a 60-minute window starting from the earliest departure at that stop.
     """
     from datetime import datetime
-    from .api import TrafikLabApiClient
 
     # ------------------------------------------------------------------
     # 1. Collect unique stop IDs with earliest departure datetime

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -25,7 +25,6 @@ from .const import (
     RESROBOT_PRODUCTS_MAP,
     CONF_INCLUDE_PLATFORM,
     DOMAIN,
-    CONF_API_KEY as _CONF_API_KEY,
 )
 from .api import TrafikLabApiClient
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -288,7 +287,7 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
             entry_type = (coordinator.entry.data.get(CONF_SENSOR_TYPE)
                           if hasattr(coordinator, "entry") else None)
             if entry_type in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
-                realtime_key = coordinator.entry.data.get(_CONF_API_KEY)
+                realtime_key = coordinator.entry.data.get(CONF_API_KEY)
                 break
 
         if not realtime_key:

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -310,7 +310,9 @@ _NON_PT_TYPES: frozenset[str] = frozenset({"WALK", "TRSF"})
 
 # Maximum number of concurrent Timetable API calls when enriching platforms.
 # Prevents bursting too many requests at once when a trip response contains
-# many unique origin stops.
+# many unique origin stops. 5 is a conservative ceiling that keeps the
+# request burst well within typical Trafiklab rate-limit budgets while still
+# providing useful parallelism for the common case (1-3 unique stops per trip).
 _PLATFORM_ENRICH_CONCURRENCY: int = 5
 
 

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -23,8 +23,10 @@ from .const import (
     CONF_UPDATE_CONDITION,
     CONF_TRANSPORT_MODES,
     RESROBOT_PRODUCTS_MAP,
+    CONF_INCLUDE_PLATFORM,
+    DOMAIN,
+    CONF_API_KEY as _CONF_API_KEY,
 )
-from .api import TrafikLabApiClient
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
@@ -158,6 +160,13 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
                     data = self._normalize_resrobot_response(data)
                 except Exception as nerr:  # pragma: no cover - defensive
                     _LOGGER.debug("Resrobot normalize failed: %s", nerr)
+
+                # Platform enrichment — opt-in via include_platform option
+                if opts.get(CONF_INCLUDE_PLATFORM):
+                    try:
+                        data = await self._enrich_platform(data)
+                    except Exception as perr:
+                        _LOGGER.warning("Platform enrichment failed: %s", perr)
                 # Mark successful update time
                 from datetime import datetime, timezone
                 self.last_successful_update = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
@@ -262,3 +271,164 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
         normalized_trips.sort(key=trip_key)
         data["Trip"] = normalized_trips
         return data
+
+    async def _enrich_platform(self, data: dict) -> dict:
+        """Annotate each public-transport leg in *data* with ``_realtime_platform``.
+
+        Resolves a Realtime API key from any departure/arrival entry in hass.data,
+        then issues one Timetable API call per unique leg-origin stop ID (batched
+        concurrently). Each matching leg gets ``_realtime_platform`` set to the
+        platform designation string (empty string when no match found).
+        """
+        # Resolve Realtime API key from a departure/arrival sensor entry
+        realtime_key: str | None = None
+        domain_data: dict = self.hass.data.get(DOMAIN, {})
+        for coordinator in domain_data.values():
+            entry_type = (coordinator.entry.data.get(CONF_SENSOR_TYPE)
+                          if hasattr(coordinator, "entry") else None)
+            if entry_type in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
+                realtime_key = coordinator.entry.data.get(_CONF_API_KEY)
+                break
+
+        if not realtime_key:
+            _LOGGER.warning(
+                "include_platform is enabled but no departure/arrival sensor with a "
+                "Realtime API key was found. Platform information will not be included."
+            )
+            return data
+
+        trips: list = (data or {}).get("Trip") or []
+        await enrich_platform_for_trips(trips, realtime_key, self.api_client.session)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper — shared by coordinator and services_setup
+# ---------------------------------------------------------------------------
+
+_NON_PT_TYPES: frozenset[str] = frozenset({"WALK", "TRSF"})
+
+
+async def enrich_platform_for_trips(
+    trips: list,
+    realtime_api_key: str,
+    session,
+) -> None:
+    """Annotate public-transport legs in *trips* with ``_realtime_platform``.
+
+    Modifies the raw Resrobot trip dicts in-place. Each public-transport leg
+    (type not in WALK/TRSF) whose ``Origin.extId`` is non-empty gets a
+    ``_realtime_platform`` key set to the platform designation string from the
+    Timetable Realtime API (empty string when no match is found).
+
+    Issues one Timetable API call per unique origin stop ID, batched concurrently,
+    each covering a 60-minute window starting from the earliest departure at that stop.
+    """
+    from datetime import datetime
+    from .api import TrafikLabApiClient
+
+    # ------------------------------------------------------------------
+    # 1. Collect unique stop IDs with earliest departure datetime
+    # ------------------------------------------------------------------
+    stop_earliest: dict[str, datetime] = {}
+
+    for trip in trips:
+        legs = (((trip or {}).get("LegList") or {}).get("Leg")) or []
+        if isinstance(legs, dict):
+            legs = [legs]
+        for leg in legs:
+            if str((leg or {}).get("type", "")).upper() in _NON_PT_TYPES:
+                continue
+            origin = (leg or {}).get("Origin") or {}
+            ext_id = origin.get("extId", "").strip()
+            if not ext_id:
+                continue
+            date_str = origin.get("date", "")
+            time_str = origin.get("time", "")
+            if not date_str or not time_str:
+                continue
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+                try:
+                    dep_dt = datetime.strptime(f"{date_str} {time_str[:8]}", fmt)
+                    break
+                except ValueError:
+                    dep_dt = None
+            if dep_dt is None:
+                continue
+            if ext_id not in stop_earliest or dep_dt < stop_earliest[ext_id]:
+                stop_earliest[ext_id] = dep_dt
+
+    if not stop_earliest:
+        return
+
+    # ------------------------------------------------------------------
+    # 2. Fetch Timetable departures for each unique stop concurrently
+    # ------------------------------------------------------------------
+    client = TrafikLabApiClient(realtime_api_key, session=session)
+
+    async def _fetch(stop_id: str, earliest: datetime):
+        time_str = earliest.strftime("%Y-%m-%dT%H:%M")
+        try:
+            result = await client.get_departures(stop_id, time_str)
+            return stop_id, result
+        except Exception as err:
+            _LOGGER.debug("Timetable call failed for stop %s: %s", stop_id, err)
+            return stop_id, {}
+
+    results = await asyncio.gather(
+        *[_fetch(sid, dt) for sid, dt in stop_earliest.items()]
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Build per-stop lookup: {stop_id: {(designation, "HH:MM"): platform}}
+    # ------------------------------------------------------------------
+    stop_lookup: dict[str, dict[tuple[str, str], str]] = {}
+    for stop_id, result in results:
+        departures: list = (result or {}).get("departures") or []
+        lookup: dict[tuple[str, str], str] = {}
+        for dep in departures:
+            route = (dep or {}).get("route") or {}
+            designation = str(route.get("designation", "")).strip()
+            scheduled = dep.get("scheduled", "")
+            # scheduled is ISO8601; extract HH:MM
+            try:
+                hhmm = scheduled[11:16] if len(scheduled) >= 16 else ""
+            except Exception:
+                hhmm = ""
+            if not designation or not hhmm:
+                continue
+            platform_str = (
+                (dep.get("realtime_platform") or {}).get("designation")
+                or (dep.get("scheduled_platform") or {}).get("designation")
+                or ""
+            )
+            key = (designation, hhmm)
+            if key not in lookup:  # keep first match (ambiguity is rare)
+                lookup[key] = platform_str
+        stop_lookup[stop_id] = lookup
+
+    # ------------------------------------------------------------------
+    # 4. Annotate legs in the raw trip data
+    # ------------------------------------------------------------------
+    for trip in trips:
+        legs = (((trip or {}).get("LegList") or {}).get("Leg")) or []
+        if isinstance(legs, dict):
+            legs = [legs]
+        for leg in legs:
+            if str((leg or {}).get("type", "")).upper() in _NON_PT_TYPES:
+                continue
+            origin = (leg or {}).get("Origin") or {}
+            ext_id = origin.get("extId", "").strip()
+            if not ext_id or ext_id not in stop_lookup:
+                continue
+            # Match designation: prefer leg.number, fall back to product.displayNumber
+            product = (leg or {}).get("Product") or {}
+            if isinstance(product, list):
+                product = product[0] if product else {}
+            designation = str(
+                leg.get("number") or product.get("displayNumber") or product.get("num") or ""
+            ).strip()
+            time_str = origin.get("time", "")
+            hhmm = time_str[:5] if len(time_str) >= 5 else ""
+            platform = stop_lookup[ext_id].get((designation, hhmm), "")
+            leg["_realtime_platform"] = platform

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -308,6 +308,11 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
 
 _NON_PT_TYPES: frozenset[str] = frozenset({"WALK", "TRSF"})
 
+# Maximum number of concurrent Timetable API calls when enriching platforms.
+# Prevents bursting too many requests at once when a trip response contains
+# many unique origin stops.
+_PLATFORM_ENRICH_CONCURRENCY: int = 5
+
 
 async def enrich_platform_for_trips(
     trips: list,
@@ -362,17 +367,20 @@ async def enrich_platform_for_trips(
 
     # ------------------------------------------------------------------
     # 2. Fetch Timetable departures for each unique stop concurrently
+    #    (concurrency capped by semaphore to avoid request bursts)
     # ------------------------------------------------------------------
     client = TrafikLabApiClient(realtime_api_key, session=session)
+    semaphore = asyncio.Semaphore(_PLATFORM_ENRICH_CONCURRENCY)
 
     async def _fetch(stop_id: str, earliest: datetime):
-        time_str = earliest.strftime("%Y-%m-%dT%H:%M")
-        try:
-            result = await client.get_departures(stop_id, time_str)
-            return stop_id, result
-        except Exception as err:
-            _LOGGER.debug("Timetable call failed for stop %s: %s", stop_id, err)
-            return stop_id, {}
+        async with semaphore:
+            time_str = earliest.strftime("%Y-%m-%dT%H:%M")
+            try:
+                result = await client.get_departures(stop_id, time_str)
+                return stop_id, result
+            except Exception as err:
+                _LOGGER.debug("Timetable call failed for stop %s: %s", stop_id, err)
+                return stop_id, {}
 
     results = await asyncio.gather(
         *[_fetch(sid, dt) for sid, dt in stop_earliest.items()]

--- a/custom_components/trafiklab/sensor.py
+++ b/custom_components/trafiklab/sensor.py
@@ -411,6 +411,8 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
                     "duration": duration_minutes,
                     # Apply translation for category using Product labels or category_map fallback
                     "category": category_full,
+                    # Platform from Timetable API cross-check (empty when not enriched or no match)
+                    "platform": leg.get("_realtime_platform", ""),
                 }
                 # attach parsed dt for sorting
                 leg_dt = parse_dt(origin.get("date", ""), origin.get("time", ""))

--- a/custom_components/trafiklab/services.yaml
+++ b/custom_components/trafiklab/services.yaml
@@ -135,3 +135,14 @@ travel_search:
           min: 1
           max: 1440
           unit_of_measurement: min
+    include_platform:
+      name: Include platform
+      description: >
+        Cross-check each public-transport leg against the Timetable Realtime API to
+        resolve the departure platform. Requires a configured departure or arrival sensor
+        (for its Realtime API key), or pass api_key explicitly. One Timetable API call
+        per unique origin stop is made.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/trafiklab/services.yaml
+++ b/custom_components/trafiklab/services.yaml
@@ -47,6 +47,17 @@ travel_search:
       selector:
         text:
           type: password
+    realtime_api_key:
+      name: Realtime API Key
+      description: >
+        Your Trafiklab Realtime (Timetable) API key, used only when include_platform is true.
+        Omit to auto-discover the key from a configured departure or arrival sensor.
+        Keeping this separate from api_key allows using different keys for Resrobot and
+        the Timetable Realtime API.
+      required: false
+      selector:
+        text:
+          type: password
     config_entry_id:
       name: Config entry ID
       description: Specific Trafiklab config entry to take the Resrobot API key from. Ignored when api_key is provided.

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -33,7 +33,9 @@ from .const import (
     SENSOR_TYPE_DEPARTURE,
     SENSOR_TYPE_ARRIVAL,
     SENSOR_TYPE_RESROBOT,
+    CONF_INCLUDE_PLATFORM,
 )
+from .coordinator import enrich_platform_for_trips
 from .sensor import normalize_resrobot_trips
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,6 +66,7 @@ TRAVEL_SEARCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_MAX_TRIP_DURATION, default=None): vol.Any(
         None, vol.All(vol.Coerce(int), vol.Range(min=1, max=1440))
     ),
+    vol.Optional(CONF_INCLUDE_PLATFORM, default=False): bool,
 })
 
 
@@ -358,6 +361,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             max_walking_distance: int = call.data.get(CONF_MAX_WALKING_DISTANCE, 1000)
             transport_modes: list[str] = call.data.get(CONF_TRANSPORT_MODES) or []
             max_trip_duration: int | None = call.data.get(CONF_MAX_TRIP_DURATION)
+            include_platform: bool = bool(call.data.get(CONF_INCLUDE_PLATFORM, False))
 
             response: dict[str, Any] = {}
             session = async_get_clientsession(hass)
@@ -491,6 +495,21 @@ def async_setup_services(hass: HomeAssistant) -> None:
                             products,
                         )
                         trips_raw.extend((result or {}).get("Trip") or [])
+
+                    if include_platform:
+                        realtime_key = _resolve_realtime_api_key(hass, call.data)
+                        if realtime_key:
+                            try:
+                                await enrich_platform_for_trips(
+                                    trips_raw, realtime_key, session
+                                )
+                            except Exception as perr:
+                                _LOGGER.warning("Platform enrichment failed in travel_search: %s", perr)
+                        else:
+                            _LOGGER.warning(
+                                "include_platform requested but no Realtime API key available "
+                                "(add a departure/arrival sensor or pass api_key explicitly)"
+                            )
 
                     trips = normalize_resrobot_trips(trips_raw, max_trip_duration)
                     response.update({"trips": trips, "total_trips": len(trips)})

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -134,6 +134,10 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
 def _find_realtime_key_from_entries(hass: HomeAssistant) -> str | None:
     """Return the Realtime API key from the first departure or arrival config entry.
 
+    "First" here means the first entry encountered during iteration over the
+    DOMAIN data dict (arbitrary / insertion order). Any departure or arrival
+    entry will work because they all carry the same type of Realtime API key.
+
     Used by ``travel_search`` platform enrichment so the Resrobot ``api_key``
     field is never mistaken for a Realtime/Timetable key.
     """

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -34,6 +34,7 @@ from .const import (
     SENSOR_TYPE_ARRIVAL,
     SENSOR_TYPE_RESROBOT,
     CONF_INCLUDE_PLATFORM,
+    CONF_REALTIME_API_KEY,
 )
 from .coordinator import enrich_platform_for_trips
 from .sensor import normalize_resrobot_trips
@@ -52,6 +53,7 @@ UPDATE_NOW_SCHEMA = vol.Schema({
 
 TRAVEL_SEARCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_REALTIME_API_KEY): cv.string,
     vol.Optional("config_entry_id"): cv.string,
     vol.Required(CONF_ORIGIN): cv.string,
     vol.Required(CONF_DESTINATION): cv.string,
@@ -125,6 +127,23 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
         return coordinator.entry.data.get(CONF_API_KEY)
     for coordinator in domain_data.values():
         if coordinator.entry.data.get(CONF_SENSOR_TYPE) == SENSOR_TYPE_RESROBOT:
+            return coordinator.entry.data.get(CONF_API_KEY)
+    return None
+
+
+def _find_realtime_key_from_entries(hass: HomeAssistant) -> str | None:
+    """Return the Realtime API key from the first departure or arrival config entry.
+
+    Used by ``travel_search`` platform enrichment so the Resrobot ``api_key``
+    field is never mistaken for a Realtime/Timetable key.
+    """
+    domain_data: dict = hass.data.get(DOMAIN, {})
+    for coordinator in domain_data.values():
+        if (
+            hasattr(coordinator, "entry")
+            and coordinator.entry.data.get(CONF_SENSOR_TYPE)
+            in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL)
+        ):
             return coordinator.entry.data.get(CONF_API_KEY)
     return None
 
@@ -497,7 +516,10 @@ def async_setup_services(hass: HomeAssistant) -> None:
                         trips_raw.extend((result or {}).get("Trip") or [])
 
                     if include_platform:
-                        realtime_key = _resolve_realtime_api_key(hass, call.data)
+                        realtime_key = (
+                            call.data.get(CONF_REALTIME_API_KEY)
+                            or _find_realtime_key_from_entries(hass)
+                        )
                         if realtime_key:
                             try:
                                 await enrich_platform_for_trips(
@@ -508,7 +530,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                         else:
                             _LOGGER.warning(
                                 "include_platform requested but no Realtime API key available "
-                                "(add a departure/arrival sensor or pass api_key explicitly)"
+                                "(add a departure/arrival sensor or pass realtime_api_key explicitly)"
                             )
 
                     trips = normalize_resrobot_trips(trips_raw, max_trip_duration)

--- a/custom_components/trafiklab/translations/en.json
+++ b/custom_components/trafiklab/translations/en.json
@@ -41,10 +41,12 @@
           "max_trip_duration": "Maximum Trip Duration (minutes, leave empty for no limit)",
           "transport_modes": "Transport Mode(s) (leave empty for all)",
           "time_window": "Time Window (minutes ahead to search)",
-          "refresh_interval": "Data Refresh Interval (seconds)"
+          "refresh_interval": "Data Refresh Interval (seconds)",
+          "include_platform": "Include platform (cross-checks Timetable Realtime API)"
         },
         "data_description": {
-          "transport_modes": "Leave empty to include all modes. Note: if set, walk and transfer legs will be excluded from results."
+          "transport_modes": "Leave empty to include all modes. Note: if set, walk and transfer legs will be excluded from results.",
+          "include_platform": "When enabled, each public-transport leg is matched against the Timetable Realtime API to resolve the departure platform. Requires a configured departure or arrival sensor. One extra API call per unique origin stop is made on each refresh."
         }
       },
       "sensor": {

--- a/custom_components/trafiklab/translations/en.json
+++ b/custom_components/trafiklab/translations/en.json
@@ -168,10 +168,12 @@
           "max_trip_duration": "Maximum Trip Duration (minutes, leave empty for no limit)",
           "transport_modes": "Transport Mode(s) (leave empty for all)",
           "time_window": "Time Window (minutes ahead to search)",
-          "refresh_interval": "Data Refresh Interval (seconds)"
+          "refresh_interval": "Data Refresh Interval (seconds)",
+          "include_platform": "Include platform (cross-checks Timetable Realtime API)"
         },
         "data_description": {
-          "transport_modes": "Leave empty to include all modes. Note: if set, walk and transfer legs will be excluded from results."
+          "transport_modes": "Leave empty to include all modes. Note: if set, walk and transfer legs will be excluded from results.",
+          "include_platform": "When enabled, each public-transport leg is matched against the Timetable Realtime API to resolve the departure platform. Requires a configured departure or arrival sensor. One extra API call per unique origin stop is made on each refresh."
         }
       }
     }

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -168,10 +168,12 @@
           "max_trip_duration": "Maximal resetid (minuter, lämna tomt för ingen gräns)",
           "transport_modes": "Transportmedel (lämna tomt för alla)",
           "time_window": "Tidsfönster (minuter framåt att söka)",
-          "refresh_interval": "Datauppdateringsintervall (sekunder)"
+          "refresh_interval": "Datauppdateringsintervall (sekunder)",
+          "include_platform": "Inkludera plattform (kors-kontroll mot Tidtabell Realtids-API)"
         },
         "data_description": {
-          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytessträckor från resultaten."
+          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytesssträckor från resultaten.",
+          "include_platform": "När aktiverat matchas varje kollektivtrafiksträcka mot Tidtabell Realtids-API för att hämta avgångsplattform. Kräver en konfigurerad avgångs- eller ankomstsensor. Ett extra API-anrop per unik ursprungshållplats görs vid varje uppdatering."
         }
       }
     }

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -172,7 +172,7 @@
           "include_platform": "Inkludera plattform (kors-kontroll mot Tidtabell Realtids-API)"
         },
         "data_description": {
-          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytesssträckor från resultaten.",
+          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytessträckor från resultaten.",
           "include_platform": "När aktiverat matchas varje kollektivtrafiksträcka mot Tidtabell Realtids-API för att hämta avgångsplattform. Kräver en konfigurerad avgångs- eller ankomstsensor. Ett extra API-anrop per unik ursprungshållplats görs vid varje uppdatering."
         }
       }

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -41,10 +41,12 @@
           "max_trip_duration": "Maximal resetid (minuter, lämna tomt för ingen gräns)",
           "transport_modes": "Transportmedel (lämna tomt för alla)",
           "time_window": "Tidsfönster (minuter framåt att söka)",
-          "refresh_interval": "Datauppdateringsintervall (sekunder)"
+          "refresh_interval": "Datauppdateringsintervall (sekunder)",
+          "include_platform": "Inkludera plattform (kors-kontroll mot Tidtabell Realtids-API)"
         },
         "data_description": {
-          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytessträckor från resultaten."
+          "transport_modes": "Lämna tomt för att inkludera alla transportmedel. OBS: Om valt exkluderas gång- och bytessträckor från resultaten.",
+          "include_platform": "När aktiverat matchas varje kollektivtrafiksträcka mot Tidtabell Realtids-API för att hämta avgångsplattform. Kräver en konfigurerad avgångs- eller ankomstsensor. Ett extra API-anrop per unik ursprungshållplats görs vid varje uppdatering."
         }
       },
       "sensor": {

--- a/tests/components/trafiklab/test_coordinator.py
+++ b/tests/components/trafiklab/test_coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 # pyright: reportMissingImports=false, reportGeneralTypeIssues=false
+import copy
 import pytest
 
 pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
@@ -56,3 +57,151 @@ async def test_coordinator_resrobot_normalizes(hass: HomeAssistant) -> None:
     # Coordinator data should have Trip as list
     coordinator = hass.data[DOMAIN][entry.entry_id]
     assert isinstance(coordinator.data.get("Trip"), list)
+
+
+# ---------------------------------------------------------------------------
+# Platform enrichment tests (CONF_INCLUDE_PLATFORM)
+# ---------------------------------------------------------------------------
+
+_PLATFORM_TRIP = {
+    "Trip": [
+        {
+            "LegList": {
+                "Leg": [
+                    {
+                        "type": "JNY",
+                        "number": "52",
+                        "Origin": {
+                            "name": "Stop A",
+                            "extId": "740000001",
+                            "date": "2025-01-01",
+                            "time": "10:00:00",
+                        },
+                        "Destination": {
+                            "name": "Stop B",
+                            "date": "2025-01-01",
+                            "time": "10:20:00",
+                        },
+                        "Product": {"name": "Bus 52", "num": "52"},
+                        "category": "BLT",
+                        "duration": "PT20M",
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+_TIMETABLE_DEPARTURES = {
+    "departures": [
+        {
+            "scheduled": "2025-01-01T10:00:00",
+            "realtime_platform": {"designation": "3"},
+            "scheduled_platform": {"designation": "3"},
+            "route": {"designation": "52"},
+        }
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_coordinator_resrobot_platform_enriched(hass: HomeAssistant) -> None:
+    """Platform enrichment populates _realtime_platform on legs when include_platform is True."""
+    # Departure entry provides the Realtime API key for platform lookup.
+    # It must be added AND loaded before the resrobot entry so that the
+    # domain is fully initialised and dep_entry appears in hass.data[DOMAIN].
+    dep_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "realtime-key",
+            "stop_id": "740098000",
+            "name": "Dep Sensor",
+            "sensor_type": "departure",
+        },
+        options={},
+        unique_id="dep-for-platform",
+    )
+    dep_entry.add_to_hass(hass)
+
+    # Set up only dep_entry first (this also initialises the domain).
+    with patch(
+        "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data",
+        return_value={},
+    ):
+        await hass.config_entries.async_setup(dep_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Add the resrobot entry AFTER the domain is loaded so HA doesn't try
+    # to set it up automatically alongside the departure entry above.
+    resrobot_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "resrobot-key",
+            "name": "Travel",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000001",
+            "destination_type": "stop_id",
+            "destination": "740000002",
+        },
+        options={"time_window": 60, "refresh_interval": 300, "include_platform": True},
+        unique_id="resrobot-platform",
+    )
+    resrobot_entry.add_to_hass(hass)
+
+    # Set up resrobot entry with mocked travel search + timetable departures.
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        side_effect=lambda *a, **kw: copy.deepcopy(_PLATFORM_TRIP),
+    ), patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        return_value=_TIMETABLE_DEPARTURES,
+    ):
+        await hass.config_entries.async_setup(resrobot_entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][resrobot_entry.entry_id]
+    trips = coordinator.data.get("Trip", [])
+    assert trips, "Expected at least one trip in coordinator data"
+    leg = trips[0]["LegList"]["Leg"][0]
+    assert leg.get("_realtime_platform") == "3", (
+        f"Expected leg to have _realtime_platform='3', got {leg.get('_realtime_platform')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_resrobot_platform_no_realtime_key(hass: HomeAssistant) -> None:
+    """When include_platform is True but no departure/arrival entry exists, data is returned without crash."""
+    # Only a Resrobot entry — no departure/arrival entry to supply the Realtime key
+    resrobot_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "resrobot-key",
+            "name": "Travel",
+            "sensor_type": "resrobot_travel_search",
+            "origin_type": "stop_id",
+            "origin": "740000001",
+            "destination_type": "stop_id",
+            "destination": "740000002",
+        },
+        options={"time_window": 60, "refresh_interval": 300, "include_platform": True},
+        unique_id="resrobot-platform-no-key",
+    )
+    resrobot_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_resrobot_travel_search",
+        side_effect=lambda *a, **kw: copy.deepcopy(_PLATFORM_TRIP),
+    ):
+        assert await hass.config_entries.async_setup(resrobot_entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Data should be present and no exception raised
+    coordinator = hass.data[DOMAIN][resrobot_entry.entry_id]
+    assert coordinator.data is not None
+    trips = coordinator.data.get("Trip", [])
+    assert isinstance(trips, list)
+    # No platform enrichment should have occurred (no departure entry with Realtime key)
+    if trips:
+        leg = trips[0]["LegList"]["Leg"][0]
+        assert "_realtime_platform" not in leg


### PR DESCRIPTION
- Added config option `include_platform` which activates cross-check against Realtime Timetable API for platform lookup
- When configured, attribute `platform` will be populated

Fixes #55 