### PR TITLE
Fix sandbox version mismatch 3.12  3.10

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v6"
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: Install requirements
         run: |
           pip install -r requirements-dev.txt

--- a/custom_components/trafiklab/__init__.py
+++ b/custom_components/trafiklab/__init__.py
@@ -116,6 +116,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool: 
         hass.config_entries.async_update_entry(entry, data=data, options=options)
         if changed:
             _LOGGER.debug("Migrated Trafiklab entry %s to version 2 (moved mutable keys to options)", entry.entry_id)
+        else:
+            _LOGGER.debug("Migrated Trafiklab entry %s to version 2", entry.entry_id)
         return True
 
     # For already-migrated entries: normalise transport_modes in options in-place

--- a/custom_components/trafiklab/__init__.py
+++ b/custom_components/trafiklab/__init__.py
@@ -112,11 +112,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool: 
                 options["transport_modes"] = cleaned
                 changed = True
 
+        entry.version = 2
         if changed:
-            hass.config_entries.async_update_entry(entry, data=data, options=options, version=2)
+            hass.config_entries.async_update_entry(entry, data=data, options=options)
             _LOGGER.debug("Migrated Trafiklab entry %s to version 2 (moved mutable keys to options)", entry.entry_id)
-        else:
-            hass.config_entries.async_update_entry(entry, version=2)
         return True
 
     # For already-migrated entries: normalise transport_modes in options in-place

--- a/custom_components/trafiklab/__init__.py
+++ b/custom_components/trafiklab/__init__.py
@@ -113,8 +113,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool: 
                 changed = True
 
         entry.version = 2
+        hass.config_entries.async_update_entry(entry, data=data, options=options)
         if changed:
-            hass.config_entries.async_update_entry(entry, data=data, options=options)
             _LOGGER.debug("Migrated Trafiklab entry %s to version 2 (moved mutable keys to options)", entry.entry_id)
         return True
 

--- a/custom_components/trafiklab/services_setup.py
+++ b/custom_components/trafiklab/services_setup.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -87,11 +87,11 @@ def _resolve_realtime_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
     if entry_id:
         coordinator = domain_data.get(entry_id)
         if coordinator is None:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 f"Config entry '{entry_id}' was not found for {DOMAIN}."
             )
         if coordinator.entry.data.get(CONF_SENSOR_TYPE) not in (SENSOR_TYPE_DEPARTURE, SENSOR_TYPE_ARRIVAL):
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 f"Config entry '{entry_id}' is not a departure or arrival entry — "
                 "only departure/arrival entries carry a Realtime API key."
             )
@@ -117,11 +117,11 @@ def _resolve_resrobot_api_key(hass: HomeAssistant, call_data: dict) -> str | Non
     if entry_id:
         coordinator = domain_data.get(entry_id)
         if coordinator is None:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 f"Config entry '{entry_id}' was not found for {DOMAIN}."
             )
         if coordinator.entry.data.get(CONF_SENSOR_TYPE) != SENSOR_TYPE_RESROBOT:
-            raise ServiceValidationError(
+            raise HomeAssistantError(
                 f"Config entry '{entry_id}' is not a Resrobot travel-search entry."
             )
         return coordinator.entry.data.get(CONF_API_KEY)
@@ -346,7 +346,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
         if entry_id is not None:
             coordinator = domain_data.get(entry_id)
             if coordinator is None:
-                raise ServiceValidationError(
+                raise HomeAssistantError(
                     f"No active Trafiklab config entry with id '{entry_id}'"
                 )
             await coordinator.async_request_refresh()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@
 # pytest-homeassistant-custom-component pins exact compatible versions of pytest,
 # pytest-asyncio, and pytest-cov; do not add separate constraints for those packages
 # here or Dependabot's one-package-at-a-time bumps will conflict with phcc's pins.
-pytest-homeassistant-custom-component>=0.13.109
+# 0.13.45 is the last release compatible with Python 3.10; 0.13.46+ requires >=3.11.
+pytest-homeassistant-custom-component==0.13.45
 
 # Code quality
 black>=26.3.1

--- a/tests/components/trafiklab/test_config_flow.py
+++ b/tests/components/trafiklab/test_config_flow.py
@@ -34,6 +34,7 @@ async def test_flow_user_selects_departure_and_configures_stop(hass: HomeAssista
             result["flow_id"],
             {"stop_id": "740098000", "line_filter": "52", "direction": "Central", "time_window": 60, "refresh_interval": 300},
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["data"]["api_key"] == "key"
@@ -70,6 +71,7 @@ async def test_flow_user_resrobot_path(hass: HomeAssistant, enable_custom_integr
                 "time_window": 60,
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["data"]["sensor_type"] == "resrobot_travel_search"
@@ -160,6 +162,7 @@ async def test_flow_departure_arrival_transport_modes_stored_in_options(hass: Ho
                 "update_condition": "",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["options"]["transport_modes"] == ["bus"]
@@ -217,6 +220,7 @@ async def test_flow_departure_arrival_no_transport_modes_defaults_to_empty(hass:
                 "update_condition": "",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert result["options"].get("transport_modes", []) == []

--- a/tests/components/trafiklab/test_config_flow.py
+++ b/tests/components/trafiklab/test_config_flow.py
@@ -11,6 +11,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.trafiklab.const import DOMAIN
 from custom_components.trafiklab.config_flow import CannotConnect, InvalidApiKey, InvalidStopId
 
+_PATCH_COORDINATOR = "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data"
+
 
 @pytest.mark.asyncio
 async def test_flow_user_selects_departure_and_configures_stop(hass: HomeAssistant, enable_custom_integrations: None) -> None:
@@ -25,8 +27,9 @@ async def test_flow_user_selects_departure_and_configures_stop(hass: HomeAssista
     assert result["type"] == "form"
     assert result["step_id"] == "departure_arrival"
 
-    # Validate helper is called and succeeds
-    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "My Stop"}):
+    # Validate helper is called and succeeds; also mock coordinator to prevent real HTTP calls
+    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "My Stop"}), \
+         patch(_PATCH_COORDINATOR, return_value={}):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"stop_id": "740098000", "line_filter": "52", "direction": "Central", "time_window": 60, "refresh_interval": 300},
@@ -51,21 +54,22 @@ async def test_flow_user_resrobot_path(hass: HomeAssistant, enable_custom_integr
     assert result["type"] == "form"
     assert result["step_id"] == "resrobot"
 
-    # Provide details and finish
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "origin_type": "stop_id",
-            "origin": "740000001",
-            "destination_type": "stop_id",
-            "destination": "740000002",
-            "via": "",
-            "avoid": "",
-            "max_walking_distance": 1000,
-            "refresh_interval": 300,
-            "time_window": 60,
-        },
-    )
+    # Provide details and finish; also mock coordinator to prevent real HTTP calls
+    with patch(_PATCH_COORDINATOR, return_value={}):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "origin_type": "stop_id",
+                "origin": "740000001",
+                "destination_type": "stop_id",
+                "destination": "740000002",
+                "via": "",
+                "avoid": "",
+                "max_walking_distance": 1000,
+                "refresh_interval": 300,
+                "time_window": 60,
+            },
+        )
 
     assert result["type"] == "create_entry"
     assert result["data"]["sensor_type"] == "resrobot_travel_search"
@@ -142,7 +146,8 @@ async def test_flow_departure_arrival_transport_modes_stored_in_options(hass: Ho
     )
     assert result["step_id"] == "departure_arrival"
 
-    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "Bus Only"}):
+    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "Bus Only"}), \
+         patch(_PATCH_COORDINATOR, return_value={}):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -199,7 +204,8 @@ async def test_flow_departure_arrival_no_transport_modes_defaults_to_empty(hass:
         {"sensor_type": "departure", "api_key": "key", "name": "All Modes"},
     )
 
-    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "All Modes"}):
+    with patch("custom_components.trafiklab.config_flow.validate_input", return_value={"title": "All Modes"}), \
+         patch(_PATCH_COORDINATOR, return_value={}):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {

--- a/tests/components/trafiklab/test_migration.py
+++ b/tests/components/trafiklab/test_migration.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 # pyright: reportMissingImports=false, reportGeneralTypeIssues=false
 
+from unittest.mock import patch
+
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -37,3 +39,26 @@ async def test_migrate_entry_v1_to_v2_moves_options(hass: HomeAssistant) -> None
     assert entry.options.get("direction") == "Cent"
     assert entry.options.get("time_window") == 60
     assert entry.options.get("refresh_interval") == 300
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_v1_to_v2_persists_version_without_data_changes(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "api_key": "k",
+            "stop_id": "740098000",
+            "name": "X",
+            "sensor_type": "departure",
+        },
+        options={"transport_modes": []},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    with patch.object(hass.config_entries, "async_update_entry", wraps=hass.config_entries.async_update_entry) as mock_update_entry:
+        ok = await async_migrate_entry(hass, entry)
+
+    assert ok is True
+    assert entry.version == 2
+    mock_update_entry.assert_called_once_with(entry, data=entry.data, options=entry.options)

--- a/tests/components/trafiklab/test_migration.py
+++ b/tests/components/trafiklab/test_migration.py
@@ -56,7 +56,11 @@ async def test_migrate_entry_v1_to_v2_persists_version_without_data_changes(hass
     )
     entry.add_to_hass(hass)
 
-    with patch.object(hass.config_entries, "async_update_entry", wraps=hass.config_entries.async_update_entry) as mock_update_entry:
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as mock_update_entry:
         ok = await async_migrate_entry(hass, entry)
 
     assert ok is True

--- a/tests/components/trafiklab/test_services.py
+++ b/tests/components/trafiklab/test_services.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from typing import Any
 
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -110,8 +110,8 @@ async def test_update_now_specific_entry(hass: HomeAssistant) -> None:
 
 @pytest.mark.asyncio
 async def test_update_now_invalid_entry_id(hass: HomeAssistant, setup_integration: bool) -> None:
-    """update_now with a non-existent entry_id raises ServiceValidationError."""
-    with pytest.raises(ServiceValidationError):
+    """update_now with a non-existent entry_id raises HomeAssistantError."""
+    with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_UPDATE_NOW,
@@ -355,8 +355,8 @@ async def test_stop_lookup_key_resolved_from_departure_entry(hass: HomeAssistant
 
 @pytest.mark.asyncio
 async def test_stop_lookup_rejects_unknown_config_entry_id(hass: HomeAssistant, setup_integration: bool) -> None:
-    """stop_lookup raises ServiceValidationError for an unknown config_entry_id."""
-    with pytest.raises(ServiceValidationError, match="not found"):
+    """stop_lookup raises HomeAssistantError for an unknown config_entry_id."""
+    with pytest.raises(HomeAssistantError, match="not found"):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_STOP_LOOKUP,
@@ -368,7 +368,7 @@ async def test_stop_lookup_rejects_unknown_config_entry_id(hass: HomeAssistant, 
 
 @pytest.mark.asyncio
 async def test_stop_lookup_rejects_resrobot_config_entry_id(hass: HomeAssistant) -> None:
-    """stop_lookup raises ServiceValidationError when a Resrobot entry_id is supplied."""
+    """stop_lookup raises HomeAssistantError when a Resrobot entry_id is supplied."""
     from tests.components.trafiklab.const import ENTRY_DATA_RESROBOT, ENTRY_OPTIONS_DEFAULT
 
     entry = MockConfigEntry(
@@ -386,7 +386,7 @@ async def test_stop_lookup_rejects_resrobot_config_entry_id(hass: HomeAssistant)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    with pytest.raises(ServiceValidationError, match="not a departure or arrival entry"):
+    with pytest.raises(HomeAssistantError, match="not a departure or arrival entry"):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_STOP_LOOKUP,


### PR DESCRIPTION
- validation workflow: [downed python version 3.11 --> 3.10](https://github.com/MrSjodin/HomeAssistant_Trafiklab_Integration/commit/1579b908eb36b8da0841fd1524d7ebf3ee45d755)
- requirements-dev: [downed pytest-homeassistant-custom-component 0.13.109 --> 0.13.45](https://github.com/MrSjodin/HomeAssistant_Trafiklab_Integration/commit/6c20b780199c569a5c086a82d14c0809463c0db0)

Plus some minor fixes to fully support HA 2023.7/Python 3.10