### PR TITLE
Better error handling from api responses

### DIFF
--- a/custom_components/trafiklab/api.py
+++ b/custom_components/trafiklab/api.py
@@ -8,8 +8,8 @@ from typing import Any
 import aiohttp
 
 from .const import (
-    API_BASE_URL, 
-    DEPARTURES_ENDPOINT, 
+    API_BASE_URL,
+    DEPARTURES_ENDPOINT,
     ARRIVALS_ENDPOINT,
     STOP_LOOKUP_ENDPOINT,
     RESROBOT_BASE_URL,
@@ -19,6 +19,128 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+class TrafikLabApiError(Exception):
+    """Base exception for all Trafiklab API errors."""
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        error_code: str | None = None,
+        http_status: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.http_status = http_status
+
+
+class TrafikLabAuthError(TrafikLabApiError):
+    """Raised when authentication fails (invalid / missing API key)."""
+
+
+class TrafikLabQuotaError(TrafikLabApiError):
+    """Raised when the API quota or rate limit is exceeded."""
+
+
+class TrafikLabNotFoundError(TrafikLabApiError):
+    """Raised when a stop / resource is not found."""
+
+
+class TrafikLabServerError(TrafikLabApiError):
+    """Raised when the API returns a server-side error (5xx)."""
+
+
+# ---------------------------------------------------------------------------
+# Private error-parsing helpers
+# ---------------------------------------------------------------------------
+
+def _raise_realtime_error(
+    status: int, body_text: str, json_body: dict | None
+) -> None:
+    """Parse a non-2xx Realtime API response and raise the appropriate exception.
+
+    Realtime error format (HTTP 403 example):
+        {"errorCode": "error.key.invalid", "errorDetail": "Key '...' does not exist.", "parameterValues": []}
+    """
+    error_code: str = ""
+    error_detail: str = ""
+    if json_body:
+        error_code = (json_body.get("errorCode") or "").lower()
+        error_detail = json_body.get("errorDetail") or json_body.get("message") or ""
+
+    message = error_detail or body_text or f"HTTP {status}"
+
+    # Auth: explicit error code patterns OR 401/403
+    if (
+        "key" in error_code
+        or "auth" in error_code
+        or "unauthorized" in error_code
+        or status in (401, 403)
+    ):
+        raise TrafikLabAuthError(message, error_code=error_code or None, http_status=status)
+
+    # Quota / rate-limit
+    if "quota" in error_code or "rate" in error_code or "limit" in error_code or status == 429:
+        raise TrafikLabQuotaError(message, error_code=error_code or None, http_status=status)
+
+    # Not found: explicit code or 404
+    if "not_found" in error_code or "stop" in error_code or "location" in error_code or status == 404:
+        raise TrafikLabNotFoundError(message, error_code=error_code or None, http_status=status)
+
+    # Server errors
+    if status >= 500:
+        raise TrafikLabServerError(message, error_code=error_code or None, http_status=status)
+
+    # Catch-all
+    raise TrafikLabApiError(message, error_code=error_code or None, http_status=status)
+
+
+def _raise_resrobot_error(
+    status: int, body_text: str, json_body: dict | None
+) -> None:
+    """Parse a non-2xx Resrobot API response and raise the appropriate exception.
+
+    Resrobot error format:
+        {"errorCode": "API_AUTH", "errorText": "access denied for ...", ...}
+
+    SVC_NO_RESULT (HTTP 200) is handled upstream as an empty Trip list, not here.
+    """
+    error_code: str = ""
+    error_text: str = ""
+    if json_body:
+        error_code = (json_body.get("errorCode") or "").upper()
+        error_text = json_body.get("errorText") or json_body.get("errorDetail") or ""
+
+    message = error_text or body_text or f"HTTP {status}"
+
+    # Auth errors
+    if error_code == "API_AUTH" or status in (401, 403):
+        raise TrafikLabAuthError(message, error_code=error_code or None, http_status=status)
+
+    # Quota / rate-limit
+    if error_code in ("API_QUOTA", "API_TOO_MANY_REQUESTS") or status == 429:
+        raise TrafikLabQuotaError(message, error_code=error_code or None, http_status=status)
+
+    # Location / not-found type errors
+    if error_code.startswith("SVC_LOC") or error_code == "SVC_NO_MATCH" or status == 404:
+        raise TrafikLabNotFoundError(message, error_code=error_code or None, http_status=status)
+
+    # Server errors
+    if error_code.startswith("INT_") or status >= 500:
+        raise TrafikLabServerError(message, error_code=error_code or None, http_status=status)
+
+    # Catch-all (bad request etc.)
+    raise TrafikLabApiError(message, error_code=error_code or None, http_status=status)
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
 
 class TrafikLabApiClient:
     """API client for Trafiklab and Resrobot endpoints."""
@@ -73,15 +195,16 @@ class TrafikLabApiClient:
                 if response.status == 200:
                     return await response.json()
                 response_text = await response.text()
-                if response.status == 403:
-                    raise TrafikLabApiError(f"Invalid API key for Resrobot: {response_text}")
-                elif response.status == 404:
-                    raise TrafikLabApiError(f"Resrobot: Not found (HTTP 404): {response_text}")
-                else:
-                    response.raise_for_status()
-                    return await response.json()
+                json_body: dict | None = None
+                try:
+                    json_body = await response.json(content_type=None)
+                except Exception:
+                    pass
+                _raise_resrobot_error(response.status, response_text, json_body)
         except asyncio.TimeoutError as err:
             raise TrafikLabApiError("Resrobot request timed out") from err
+        except TrafikLabApiError:
+            raise
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Resrobot request failed: {err}") from err
     def __init__(self, api_key: str, session: aiohttp.ClientSession | None = None, timeout: int = 15) -> None:
@@ -128,34 +251,21 @@ class TrafikLabApiClient:
 
         try:
             async with self.session.get(url, params=params) as response:
-                # Don't raise for status immediately, check the response first
                 if response.status == 200:
                     return await response.json()
-                
-                # Handle specific HTTP status codes
+
                 response_text = await response.text()
-                
-                if response.status == 403:
-                    # Parse JSON error if available
-                    try:
-                        error_data = await response.json()
-                        error_code = error_data.get("errorCode", "")
-                        error_detail = error_data.get("errorDetail", "")
-                        if "key" in error_code.lower() or "key" in error_detail.lower():
-                            raise TrafikLabApiError(f"Invalid API key: {error_detail}")
-                    except Exception:
-                        pass
-                    raise TrafikLabApiError(f"API key authentication failed (HTTP 403): {response_text}")
-                
-                elif response.status == 404:
-                    raise TrafikLabApiError(f"Stop ID not found (HTTP 404): {response_text}")
-                
-                else:
-                    response.raise_for_status()
-                    return await response.json()
-                    
+                json_body: dict | None = None
+                try:
+                    json_body = await response.json(content_type=None)
+                except Exception:
+                    pass
+                _raise_realtime_error(response.status, response_text, json_body)
+
         except asyncio.TimeoutError as err:
             raise TrafikLabApiError("Request timed out") from err
+        except TrafikLabApiError:
+            raise
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Request failed: {err}") from err
 
@@ -174,10 +284,19 @@ class TrafikLabApiClient:
 
         try:
             async with self.session.get(url, params=params) as response:
-                response.raise_for_status()
-                return await response.json()
+                if response.status == 200:
+                    return await response.json()
+                response_text = await response.text()
+                json_body: dict | None = None
+                try:
+                    json_body = await response.json(content_type=None)
+                except Exception:
+                    pass
+                _raise_realtime_error(response.status, response_text, json_body)
         except asyncio.TimeoutError as err:
             raise TrafikLabApiError("Request timed out") from err
+        except TrafikLabApiError:
+            raise
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Request failed: {err}") from err
 
@@ -188,10 +307,19 @@ class TrafikLabApiClient:
 
         try:
             async with self.session.get(url, params=params) as response:
-                response.raise_for_status()
-                return await response.json()
+                if response.status == 200:
+                    return await response.json()
+                response_text = await response.text()
+                json_body: dict | None = None
+                try:
+                    json_body = await response.json(content_type=None)
+                except Exception:
+                    pass
+                _raise_realtime_error(response.status, response_text, json_body)
         except asyncio.TimeoutError as err:
             raise TrafikLabApiError("Request timed out") from err
+        except TrafikLabApiError:
+            raise
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Request failed: {err}") from err
 
@@ -215,13 +343,16 @@ class TrafikLabApiClient:
                     _LOGGER.debug("Resrobot location.name raw response for %r: %s", search_value, data)
                     return data
                 response_text = await response.text()
-                if response.status == 403:
-                    raise TrafikLabApiError(f"Invalid Resrobot API key: {response_text}")
-                else:
-                    response.raise_for_status()
-                    return await response.json()
+                json_body: dict | None = None
+                try:
+                    json_body = await response.json(content_type=None)
+                except Exception:
+                    pass
+                _raise_resrobot_error(response.status, response_text, json_body)
         except asyncio.TimeoutError as err:
             raise TrafikLabApiError("Resrobot location lookup timed out") from err
+        except TrafikLabApiError:
+            raise
         except aiohttp.ClientError as err:
             raise TrafikLabApiError(f"Resrobot location lookup failed: {err}") from err
 
@@ -232,7 +363,3 @@ class TrafikLabApiClient:
             return True
         except TrafikLabApiError:
             return False
-
-
-class TrafikLabApiError(Exception):
-    """Exception for Trafiklab API errors."""

--- a/custom_components/trafiklab/config_flow.py
+++ b/custom_components/trafiklab/config_flow.py
@@ -18,7 +18,13 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .api import TrafikLabApiClient, TrafikLabApiError
+from .api import (
+    TrafikLabApiClient,
+    TrafikLabApiError,
+    TrafikLabAuthError,
+    TrafikLabQuotaError,
+    TrafikLabNotFoundError,
+)
 
 from .const import (
     DOMAIN,
@@ -148,6 +154,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         errors["api_key"] = "invalid_api_key"
                     except InvalidStopId:
                         errors["stop_id"] = "invalid_stop_id"
+                    except QuotaExceeded:
+                        errors["base"] = "quota_exceeded"
                     except CannotConnect:
                         errors["base"] = "cannot_connect"
                     except Exception as err:  # pragma: no cover
@@ -200,6 +208,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["api_key"] = "invalid_api_key"
             except InvalidStopId:
                 errors["stop_id"] = "invalid_stop_id"
+            except QuotaExceeded:
+                errors["base"] = "quota_exceeded"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception as err:
@@ -297,6 +307,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["origin"] = "invalid_coordinates"
             if destination_type == "coordinates" and not valid_coords(destination):
                 errors["destination"] = "invalid_coordinates"
+
+            if not errors:
+                # Probe Resrobot API to validate the key before saving
+                from homeassistant.helpers.aiohttp_client import async_get_clientsession
+                _probe_client = TrafikLabApiClient(
+                    self._api_key, session=async_get_clientsession(self.hass)
+                )
+                try:
+                    await _probe_client.search_resrobot_stops("Stockholm", self._api_key)
+                except TrafikLabAuthError:
+                    errors["base"] = "invalid_api_key"
+                except TrafikLabQuotaError:
+                    errors["base"] = "quota_exceeded"
+                except TrafikLabApiError:
+                    errors["base"] = "cannot_connect"
+                except Exception:  # pragma: no cover
+                    errors["base"] = "cannot_connect"
+                finally:
+                    await _probe_client.close()
 
             if not errors:
                 # Store config and create entry
@@ -413,6 +442,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["api_key"] = "invalid_api_key"
             except InvalidStopId:
                 errors["stop_id"] = "invalid_stop_id"
+            except QuotaExceeded:
+                errors["base"] = "quota_exceeded"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception as err:
@@ -455,6 +486,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_ORIGIN] = "invalid_coordinates"
             if user_input.get(CONF_DESTINATION_TYPE) == "coordinates" and not valid_coords(user_input.get(CONF_DESTINATION, "")):
                 errors[CONF_DESTINATION] = "invalid_coordinates"
+
+            if not errors:
+                # Probe Resrobot API to validate the key before saving
+                from homeassistant.helpers.aiohttp_client import async_get_clientsession
+                _probe_client = TrafikLabApiClient(
+                    user_input[CONF_API_KEY], session=async_get_clientsession(self.hass)
+                )
+                try:
+                    await _probe_client.search_resrobot_stops("Stockholm", user_input[CONF_API_KEY])
+                except TrafikLabAuthError:
+                    errors["base"] = "invalid_api_key"
+                except TrafikLabQuotaError:
+                    errors["base"] = "quota_exceeded"
+                except TrafikLabApiError:
+                    errors["base"] = "cannot_connect"
+                except Exception:  # pragma: no cover
+                    errors["base"] = "cannot_connect"
+                finally:
+                    await _probe_client.close()
 
             if not errors:
                 return self.async_update_reload_and_abort(
@@ -577,6 +627,10 @@ class InvalidStopId(HomeAssistantError):
     """Error to indicate the stop id is invalid."""
 
 
+class QuotaExceeded(HomeAssistantError):
+    """Error to indicate the API quota has been exceeded."""
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -591,12 +645,13 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     try:
         # Attempt a lightweight departures fetch to validate both key & stop.
         await client.get_departures(stop_id)
+    except TrafikLabAuthError as err:
+        raise InvalidApiKey from err
+    except TrafikLabNotFoundError as err:
+        raise InvalidStopId from err
+    except TrafikLabQuotaError as err:
+        raise QuotaExceeded from err
     except TrafikLabApiError as err:
-        lower = str(err).lower()
-        if "invalid api key" in lower or "authentication failed" in lower:
-            raise InvalidApiKey from err
-        if "not found" in lower or "stop id" in lower:
-            raise InvalidStopId from err
         raise CannotConnect from err
     except Exception as err:  # pragma: no cover - network/aio edge case
         raise CannotConnect from err

--- a/custom_components/trafiklab/coordinator.py
+++ b/custom_components/trafiklab/coordinator.py
@@ -26,8 +26,15 @@ from .const import (
     CONF_INCLUDE_PLATFORM,
     DOMAIN,
 )
-from .api import TrafikLabApiClient
+from .api import (
+    TrafikLabApiClient,
+    TrafikLabApiError,
+    TrafikLabAuthError,
+    TrafikLabQuotaError,
+    TrafikLabServerError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.issue_registry as ir
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +50,8 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
         self.api_client = TrafikLabApiClient(entry.data[CONF_API_KEY], session=session)
         # Track last successful update (UTC ISO8601)
         self.last_successful_update: str | None = None
+        # Track last API error (None when healthy)
+        self.last_api_error: dict | None = None
 
         # Options override data if present
         refresh_interval = entry.options.get(
@@ -170,6 +179,8 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
                 # Mark successful update time
                 from datetime import datetime, timezone
                 self.last_successful_update = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+                self.last_api_error = None
+                ir.async_delete_issue(self.hass, DOMAIN, f"invalid_api_key_{self.entry.entry_id}")
                 return data
             else:
                 stop_id = self.entry.data[CONF_STOP_ID]
@@ -195,10 +206,66 @@ class TrafikLabCoordinator(DataUpdateCoordinator):
                 # Mark successful update time (UTC ISO8601 without microseconds)
                 from datetime import datetime, timezone
                 self.last_successful_update = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+                self.last_api_error = None
+                ir.async_delete_issue(self.hass, DOMAIN, f"invalid_api_key_{self.entry.entry_id}")
                 return data
             
-        except Exception as err:
+        except TrafikLabAuthError as err:
+            self.last_api_error = {
+                "code": err.error_code or "auth_error",
+                "message": str(err),
+                "http_status": err.http_status,
+            }
+            _LOGGER.error(
+                "Authentication error for %s — API key is invalid or unauthorized: %s",
+                self.entry.title,
+                err,
+            )
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                f"invalid_api_key_{self.entry.entry_id}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="invalid_api_key",
+                translation_placeholders={"entry_title": self.entry.title},
+            )
+            raise UpdateFailed(f"Authentication error: {err}") from err
+        except TrafikLabQuotaError as err:
+            self.last_api_error = {
+                "code": err.error_code or "quota_exceeded",
+                "message": str(err),
+                "http_status": err.http_status,
+            }
+            _LOGGER.warning(
+                "Quota or rate-limit exceeded for %s: %s", self.entry.title, err
+            )
+            raise UpdateFailed(f"Quota exceeded: {err}") from err
+        except TrafikLabServerError as err:
+            self.last_api_error = {
+                "code": err.error_code or "server_error",
+                "message": str(err),
+                "http_status": err.http_status,
+            }
+            _LOGGER.warning(
+                "Trafiklab server error for %s: %s", self.entry.title, err
+            )
+            raise UpdateFailed(f"Server error: {err}") from err
+        except TrafikLabApiError as err:
+            self.last_api_error = {
+                "code": err.error_code or "api_error",
+                "message": str(err),
+                "http_status": err.http_status,
+            }
             _LOGGER.error("Error communicating with API: %s", err)
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+        except Exception as err:
+            self.last_api_error = {
+                "code": "unexpected_error",
+                "message": str(err),
+                "http_status": None,
+            }
+            _LOGGER.error("Unexpected error communicating with API: %s", err)
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     def _normalize_resrobot_response(self, data: dict) -> dict:

--- a/custom_components/trafiklab/sensor.py
+++ b/custom_components/trafiklab/sensor.py
@@ -179,24 +179,31 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        api_error = getattr(self.coordinator, "last_api_error", None)
         if not self.coordinator.data:
-            return {}
+            attrs: dict[str, Any] = {}
+            self._inject_api_error(attrs)
+            return attrs
         sensor_type = self._entry.data.get(CONF_SENSOR_TYPE, "departure")
         if sensor_type == "resrobot_travel_search":
             # Build a sorted top-level trips array and per-trip sorted legs array
             trips_raw = self.coordinator.data.get("Trip", [])
             if not trips_raw:
-                return {}
+                attrs = {}
+                self._inject_api_error(attrs)
+                return attrs
             options_merged = {**self._entry.options, **self._entry.data}
             max_trip_duration: int | None = options_merged.get(CONF_MAX_TRIP_DURATION)
             trips_sorted = self._normalize_resrobot_trips(trips_raw, max_trip_duration)
-            return {
+            attrs: dict[str, Any] = {
                 "num_trips": len(trips_sorted),
                 "trips": trips_sorted,
                 "attribution": "Data from Resrobot/Trafiklab.se",
                 "last_update": getattr(self.coordinator, "last_successful_update", None),
                 "integration": DOMAIN,
             }
+            self._inject_api_error(attrs)
+            return attrs
         # ...existing code for departure/arrival...
         items = self._get_data_items()
         if not items:
@@ -204,7 +211,7 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
         first_item = items[0]
         merged_cfg = {**self._entry.data, **self._entry.options}
         configured_direction = merged_cfg.get(CONF_DIRECTION, "")
-        return {
+        attrs = {
             "line": (first_item.get("route") or {}).get("designation", ""),
             "destination": (first_item.get("route") or {}).get("direction", ""),
             "direction": configured_direction,
@@ -220,6 +227,15 @@ class TrafikLabSensor(CoordinatorEntity[TrafikLabCoordinator], SensorEntity):
             "last_update": getattr(self.coordinator, "last_successful_update", None),
             "integration": DOMAIN,
         }
+        self._inject_api_error(attrs)
+        return attrs
+
+    def _inject_api_error(self, attrs: dict[str, Any]) -> None:
+        """Inject api_error_code/api_error_message into attrs when coordinator has an error."""
+        api_error = getattr(self.coordinator, "last_api_error", None)
+        if api_error:
+            attrs["api_error_code"] = api_error.get("code")
+            attrs["api_error_message"] = api_error.get("message")
 
     def _build_upcoming_array(
         self, items: list[dict], configured_direction: str

--- a/custom_components/trafiklab/translations/en.json
+++ b/custom_components/trafiklab/translations/en.json
@@ -92,6 +92,7 @@
       "invalid_api_key": "Invalid API key",
       "invalid_stop_id": "Invalid stop ID",
       "invalid_coordinates": "Invalid coordinates format (lat,lon)",
+      "quota_exceeded": "API quota exceeded — wait before trying again",
       "unknown": "Unexpected error occurred"
     },
     "abort": {
@@ -178,6 +179,12 @@
           "include_platform": "When enabled, each public-transport leg is matched against the Timetable Realtime API to resolve the departure platform. Requires a configured departure or arrival sensor. One extra API call per unique origin stop is made on each refresh."
         }
       }
+    }
+  },
+  "issues": {
+    "invalid_api_key": {
+      "title": "Invalid Trafiklab API key for {entry_title}",
+      "description": "The API key configured for **{entry_title}** is unauthorized. Please reconfigure the integration with a valid Trafiklab API key."
     }
   }
 }

--- a/custom_components/trafiklab/translations/sv.json
+++ b/custom_components/trafiklab/translations/sv.json
@@ -92,6 +92,7 @@
       "invalid_api_key": "Ogiltig API-nyckel",
       "invalid_stop_id": "Ogiltigt hållplats-ID",
       "invalid_coordinates": "Ogiltigt koordinatformat (lat,lon)",
+      "quota_exceeded": "API-kvot överskriden — vänta innan du försöker igen",
       "unknown": "Oväntat fel uppstod"
     },
     "abort": {
@@ -178,6 +179,12 @@
           "include_platform": "När aktiverat matchas varje kollektivtrafiksträcka mot Tidtabell Realtids-API för att hämta avgångsplattform. Kräver en konfigurerad avgångs- eller ankomstsensor. Ett extra API-anrop per unik ursprungshållplats görs vid varje uppdatering."
         }
       }
+    }
+  },
+  "issues": {
+    "invalid_api_key": {
+      "title": "Ogiltig Trafiklab API-nyckel för {entry_title}",
+      "description": "API-nyckeln konfigurerad för **{entry_title}** är ej behörig. Konfigurera om integrationen med en giltig Trafiklab API-nyckel."
     }
   }
 }

--- a/tests/components/trafiklab/test_config_flow.py
+++ b/tests/components/trafiklab/test_config_flow.py
@@ -9,7 +9,8 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.trafiklab.const import DOMAIN
-from custom_components.trafiklab.config_flow import CannotConnect, InvalidApiKey, InvalidStopId
+from custom_components.trafiklab.config_flow import CannotConnect, InvalidApiKey, InvalidStopId, QuotaExceeded
+from custom_components.trafiklab.api import TrafikLabAuthError, TrafikLabNotFoundError, TrafikLabQuotaError, TrafikLabApiError
 
 _PATCH_COORDINATOR = "custom_components.trafiklab.coordinator.TrafikLabCoordinator._async_update_data"
 
@@ -56,7 +57,9 @@ async def test_flow_user_resrobot_path(hass: HomeAssistant, enable_custom_integr
     assert result["step_id"] == "resrobot"
 
     # Provide details and finish; also mock coordinator to prevent real HTTP calls
-    with patch(_PATCH_COORDINATOR, return_value={}):
+    _PATCH_RESROBOT_PROBE = "custom_components.trafiklab.api.TrafikLabApiClient.search_resrobot_stops"
+    with patch(_PATCH_COORDINATOR, return_value={}), \
+         patch(_PATCH_RESROBOT_PROBE, return_value={"StopLocation": []}):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -178,21 +181,24 @@ async def test_flow_resrobot_transport_modes_stored_in_options(hass: HomeAssista
     )
     assert result["step_id"] == "resrobot"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "origin_type": "stop_id",
-            "origin": "740000001",
-            "destination_type": "stop_id",
-            "destination": "740000002",
-            "via": "",
-            "avoid": "",
-            "max_walking_distance": 1000,
-            "transport_modes": ["train", "metro"],
-            "refresh_interval": 300,
-            "time_window": 60,
-        },
-    )
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.search_resrobot_stops", return_value={"StopLocation": []}), \
+         patch(_PATCH_COORDINATOR, return_value={}):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "origin_type": "stop_id",
+                "origin": "740000001",
+                "destination_type": "stop_id",
+                "destination": "740000002",
+                "via": "",
+                "avoid": "",
+                "max_walking_distance": 1000,
+                "transport_modes": ["train", "metro"],
+                "refresh_interval": 300,
+                "time_window": 60,
+            },
+        )
+        await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
     assert set(result["options"]["transport_modes"]) == {"train", "metro"}
@@ -255,4 +261,93 @@ async def test_options_flow_clear_line_filter(hass: HomeAssistant, enable_custom
     assert result["type"] == "create_entry"
     assert result["data"]["line_filter"] == ""
     assert result["data"]["direction"] == "Cent"
+
+
+# ---------------------------------------------------------------------------
+# New error-handling tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_auth_error_to_invalid_api_key(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+    """TrafikLabAuthError from the API client must be re-raised as InvalidApiKey."""
+    from custom_components.trafiklab.config_flow import validate_input
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabAuthError("access denied", error_code="API_AUTH", http_status=403),
+    ):
+        with pytest.raises(InvalidApiKey):
+            await validate_input(hass, {"api_key": "bad-key", "stop_id": "740098000"})
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_not_found_to_invalid_stop_id(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+    """TrafikLabNotFoundError from the API client must be re-raised as InvalidStopId."""
+    from custom_components.trafiklab.config_flow import validate_input
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabNotFoundError("stop not found", http_status=404),
+    ):
+        with pytest.raises(InvalidStopId):
+            await validate_input(hass, {"api_key": "key", "stop_id": "000000"})
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_quota_error_to_quota_exceeded(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+    """TrafikLabQuotaError from the API client must be re-raised as QuotaExceeded."""
+    from custom_components.trafiklab.config_flow import validate_input
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabQuotaError("quota exceeded", http_status=429),
+    ):
+        with pytest.raises(QuotaExceeded):
+            await validate_input(hass, {"api_key": "key", "stop_id": "740098000"})
+
+
+@pytest.mark.asyncio
+async def test_flow_quota_exceeded_shows_correct_error(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+    """quota_exceeded error key must appear on errors['base'] when QuotaExceeded is raised."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"sensor_type": "departure", "api_key": "key", "name": "Stop"},
+    )
+    with patch("custom_components.trafiklab.config_flow.validate_input", side_effect=QuotaExceeded()):
+        result_err = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"stop_id": "740098000"}
+        )
+    assert result_err["type"] == "form"
+    assert result_err["errors"].get("base") == "quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_resrobot_step_auth_error_shows_invalid_api_key(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+    """A TrafikLabAuthError from the Resrobot probe must show invalid_api_key on errors['base']."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"sensor_type": "resrobot_travel_search", "api_key": "bad-key", "name": "Trip"},
+    )
+    assert result["step_id"] == "resrobot"
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.search_resrobot_stops",
+        side_effect=TrafikLabAuthError("access denied", http_status=401),
+    ):
+        result_err = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "origin_type": "stop_id",
+                "origin": "740000001",
+                "destination_type": "stop_id",
+                "destination": "740000002",
+                "via": "",
+                "avoid": "",
+                "max_walking_distance": 1000,
+                "refresh_interval": 300,
+                "time_window": 60,
+            },
+        )
+
+    assert result_err["type"] == "form"
+    assert result_err["errors"].get("base") == "invalid_api_key"
 

--- a/tests/components/trafiklab/test_coordinator.py
+++ b/tests/components/trafiklab/test_coordinator.py
@@ -205,3 +205,138 @@ async def test_coordinator_resrobot_platform_no_realtime_key(hass: HomeAssistant
     if trips:
         leg = trips[0]["LegList"]["Leg"][0]
         assert "_realtime_platform" not in leg
+
+
+# ---------------------------------------------------------------------------
+# Error-handling tests for coordinator
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_coordinator_auth_error_sets_last_api_error_and_repair_issue(hass: HomeAssistant) -> None:
+    """TrafikLabAuthError must set last_api_error and create a repair issue."""
+    from homeassistant.helpers import issue_registry as ir
+    from custom_components.trafiklab.api import TrafikLabAuthError
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "bad-key", "stop_id": "740098000", "name": "X", "sensor_type": "departure"},
+        options={},
+        unique_id="coord-auth-err",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabAuthError("access denied", http_status=403),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Reset and do exactly one controlled refresh
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabAuthError("access denied", http_status=403),
+    ):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        with pytest.raises(Exception):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    assert coordinator.last_api_error is not None
+    assert coordinator.last_api_error["http_status"] == 403
+
+    issue_reg = ir.async_get(hass)
+    issue_id = f"invalid_api_key_{entry.entry_id}"
+    assert issue_reg.async_get_issue(DOMAIN, issue_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_success_clears_last_api_error_and_repair_issue(hass: HomeAssistant) -> None:
+    """A successful update must clear last_api_error and delete any existing repair issue."""
+    from homeassistant.helpers import issue_registry as ir
+    from custom_components.trafiklab.api import TrafikLabAuthError
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "key", "stop_id": "740098000", "name": "X", "sensor_type": "departure"},
+        options={},
+        unique_id="coord-success-clear",
+    )
+    entry.add_to_hass(hass)
+
+    # First: fail with auth error to plant the issue
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabAuthError("access denied", http_status=403),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabAuthError("access denied", http_status=403),
+    ):
+        with pytest.raises(Exception):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    # Confirm issue was created
+    issue_reg = ir.async_get(hass)
+    issue_id = f"invalid_api_key_{entry.entry_id}"
+    assert issue_reg.async_get_issue(DOMAIN, issue_id) is not None
+
+    # Now succeed — issue and error should be cleared
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        return_value={"departures": []},
+    ):
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    assert coordinator.last_api_error is None
+    assert issue_reg.async_get_issue(DOMAIN, issue_id) is None
+
+
+@pytest.mark.asyncio
+async def test_coordinator_quota_error_sets_last_api_error_no_repair_issue(hass: HomeAssistant) -> None:
+    """TrafikLabQuotaError must set last_api_error but must NOT create a repair issue."""
+    from homeassistant.helpers import issue_registry as ir
+    from custom_components.trafiklab.api import TrafikLabQuotaError
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "key", "stop_id": "740098000", "name": "X", "sensor_type": "departure"},
+        options={},
+        unique_id="coord-quota-err",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        return_value={"departures": []},
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.last_api_error = None  # ensure clean state
+
+    with patch(
+        "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
+        side_effect=TrafikLabQuotaError("quota exceeded", http_status=429),
+    ):
+        with pytest.raises(Exception):
+            await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    assert coordinator.last_api_error is not None
+    assert coordinator.last_api_error["http_status"] == 429
+
+    # No repair issue for quota errors
+    issue_reg = ir.async_get(hass)
+    issue_id = f"invalid_api_key_{entry.entry_id}"
+    assert issue_reg.async_get_issue(DOMAIN, issue_id) is None
+

--- a/tests/components/trafiklab/test_coordinator.py
+++ b/tests/components/trafiklab/test_coordinator.py
@@ -225,23 +225,24 @@ async def test_coordinator_auth_error_sets_last_api_error_and_repair_issue(hass:
     )
     entry.add_to_hass(hass)
 
+    # Setup with a successful mock to avoid ConfigEntryNotReady during first refresh
     with patch(
         "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
-        side_effect=TrafikLabAuthError("access denied", http_status=403),
+        return_value={"departures": []},
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator.last_api_error = None  # ensure clean state
 
-    # Reset and do exactly one controlled refresh
+    # Do exactly one controlled refresh with auth error
+    # Note: async_refresh() does not raise — UpdateFailed is handled internally
     with patch(
         "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
         side_effect=TrafikLabAuthError("access denied", http_status=403),
     ):
-        from homeassistant.helpers.update_coordinator import UpdateFailed
-        with pytest.raises(Exception):
-            await coordinator.async_refresh()
+        await coordinator.async_refresh()
         await hass.async_block_till_done()
 
     assert coordinator.last_api_error is not None
@@ -266,21 +267,21 @@ async def test_coordinator_success_clears_last_api_error_and_repair_issue(hass: 
     )
     entry.add_to_hass(hass)
 
-    # First: fail with auth error to plant the issue
+    # Setup with success, then plant the auth error via a controlled refresh
     with patch(
         "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
-        side_effect=TrafikLabAuthError("access denied", http_status=403),
+        return_value={"departures": []},
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    # Note: async_refresh() does not raise — UpdateFailed is handled internally
     with patch(
         "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
         side_effect=TrafikLabAuthError("access denied", http_status=403),
     ):
-        with pytest.raises(Exception):
-            await coordinator.async_refresh()
+        await coordinator.async_refresh()
         await hass.async_block_till_done()
 
     # Confirm issue was created
@@ -324,12 +325,12 @@ async def test_coordinator_quota_error_sets_last_api_error_no_repair_issue(hass:
     coordinator = hass.data[DOMAIN][entry.entry_id]
     coordinator.last_api_error = None  # ensure clean state
 
+    # Note: async_refresh() does not raise — UpdateFailed is handled internally
     with patch(
         "custom_components.trafiklab.api.TrafikLabApiClient.get_departures",
         side_effect=TrafikLabQuotaError("quota exceeded", http_status=429),
     ):
-        with pytest.raises(Exception):
-            await coordinator.async_refresh()
+        await coordinator.async_refresh()
         await hass.async_block_till_done()
 
     assert coordinator.last_api_error is not None

--- a/tests/components/trafiklab/test_sensor.py
+++ b/tests/components/trafiklab/test_sensor.py
@@ -583,3 +583,93 @@ async def test_resrobot_multi_mode_merges_and_deduplicates_trips(hass: HomeAssis
     categories = {leg["category"] for trip in trips for leg in trip.get("legs", [])}
     assert "Metro" in categories
     assert "Bus" in categories
+
+
+# ---------------------------------------------------------------------------
+# Tests for api_error_code / api_error_message sensor attributes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sensor_exposes_api_error_attributes_when_coordinator_has_error(hass: HomeAssistant) -> None:
+    """When coordinator.last_api_error is set, sensor attrs must expose api_error_code and api_error_message."""
+    from custom_components.trafiklab.api import TrafikLabAuthError
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "key", "stop_id": "740098000", "name": "ErrAttr", "sensor_type": "departure"},
+        options={"time_window": 60, "refresh_interval": 300},
+        unique_id="err_attr_test",
+    )
+    entry.add_to_hass(hass)
+
+    # Set up with good data first so we get an entity
+    from datetime import datetime, timedelta
+    future = (datetime.now() + timedelta(minutes=10)).isoformat()
+    good_response = {"departures": [{
+        "scheduled": future, "realtime": future, "is_realtime": True, "delay": 0,
+        "canceled": False, "realtime_platform": None, "scheduled_platform": None,
+        "route": {"designation": "52", "direction": "Central", "transport_mode": "BUS", "name": "Bus 52"},
+        "agency": {"name": "SL"}, "trip": {"trip_id": "t1"},
+    }]}
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_departures", return_value=good_response):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Manually plant an API error into the coordinator (simulates a failed refresh)
+    coordinator.last_api_error = {
+        "code": "API_AUTH",
+        "message": "access denied",
+        "http_status": 403,
+    }
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_next_departure")
+    assert entity_id is not None
+
+    # Force a state write so HA picks up the updated attributes
+    coordinator.async_set_updated_data(good_response)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    attrs = state.attributes
+    assert attrs.get("api_error_code") == "API_AUTH"
+    assert attrs.get("api_error_message") == "access denied"
+
+
+@pytest.mark.asyncio
+async def test_sensor_no_error_attributes_when_healthy(hass: HomeAssistant) -> None:
+    """When coordinator.last_api_error is None, api_error_code must not appear in attributes."""
+    from datetime import datetime, timedelta
+    future = (datetime.now() + timedelta(minutes=5)).isoformat()
+    good_response = {"departures": [{
+        "scheduled": future, "realtime": future, "is_realtime": True, "delay": 0,
+        "canceled": False, "realtime_platform": None, "scheduled_platform": None,
+        "route": {"designation": "7", "direction": "T-Centralen", "transport_mode": "TRAM", "name": "Spårväg 7"},
+        "agency": {"name": "SL"}, "trip": {"trip_id": "t7"},
+    }]}
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"api_key": "key", "stop_id": "740098000", "name": "Healthy", "sensor_type": "departure"},
+        options={"time_window": 60, "refresh_interval": 300},
+        unique_id="no_err_attr_test",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.trafiklab.api.TrafikLabApiClient.get_departures", return_value=good_response):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    from homeassistant.helpers import entity_registry as er
+    ent_reg = er.async_get(hass)
+    entity_id = ent_reg.async_get_entity_id("sensor", "trafiklab", f"{entry.entry_id}_next_departure")
+    assert entity_id is not None
+    attrs = hass.states.get(entity_id).attributes
+    assert "api_error_code" not in attrs
+    assert "api_error_message" not in attrs
+


### PR DESCRIPTION
Fixes #67 by evaluating API response that:
- Throws up more human understandable errors
- Logs errors to HA log
- Logs last error to attribute `last_api_error`
- Tests API connection in config flow for invalid key error